### PR TITLE
#125 - Update Polkadex ParaID

### DIFF
--- a/packages/extension-koni-base/src/api/endpoints.ts
+++ b/packages/extension-koni-base/src/api/endpoints.ts
@@ -246,7 +246,7 @@ const NETWORKS: Record<string, NetWorkInfo> = {
     ss58Format: 88,
     provider: 'wss://mainnet.polkadex.trade',
     groups: ['POLKADOT_PARACHAIN'],
-    paraId: 2036,
+    paraId: 2040,
     nativeToken: 'PDEX',
     crowdloanUrl: 'https://www.polkadex.trade/crowdloans'
   },


### PR DESCRIPTION
### Related issue

#125 - Update Polkadex ParaID

### Is your feature request related to a problem? Please describe.

Dagmara H - Polkadex

As a heads up we'll be entering the Crowdloan on Monday, April 4th (that is one day earlier than previously planned). We’ll share with you our paraID as soon as we have it. It would be great if you could follow up with the adjustments on your side as soon as possible 🙏 We also made some changes to the crowdloan structure and rewards distribution, making it more attractive for the contributors 🙂

Crowdloan Structure:
DOT Cap: 1M
PDEX Pool: 2M
Base Reward (PDEX/DOT): 2+
Lease Period: 8-15
Ending Block: 10,881,400
Para ID: 2040