### PR TITLE
Fix bug tooltip not showing on the popup view on firefox browser

### DIFF
--- a/patches/react-tooltip+4.2.21.patch
+++ b/patches/react-tooltip+4.2.21.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-tooltip/dist/index.es.js b/node_modules/react-tooltip/dist/index.es.js
+index 8fa98b4..e3d3599 100644
+--- a/node_modules/react-tooltip/dist/index.es.js
++++ b/node_modules/react-tooltip/dist/index.es.js
+@@ -261,7 +261,7 @@ function windowListener (target) {
+ 
+   target.prototype.onWindowResize = function () {
+     if (!this.mount) return;
+-    this.hideTooltip();
++    // this.hideTooltip();
+   };
+ }
+ 


### PR DESCRIPTION
Pull request for task #224
Fix bug tooltip not showing on the popup view on firefox browser