### PR TITLE
Fix bug not showing GLMR price

### DIFF
--- a/packages/extension-koni-base/src/background/handlers/State.ts
+++ b/packages/extension-koni-base/src/background/handlers/State.ts
@@ -220,7 +220,6 @@ export default class KoniState extends State {
               mergedNetworkMap[key].active = storedNetwork.active;
             }
 
-            mergedNetworkMap[key].coinGeckoKey = storedNetwork.coinGeckoKey;
             mergedNetworkMap[key].crowdloanUrl = storedNetwork.crowdloanUrl;
             mergedNetworkMap[key].blockExplorer = storedNetwork.blockExplorer;
             mergedNetworkMap[key].currentProviderMode = mergedNetworkMap[key].currentProvider.startsWith('http') ? 'http' : 'ws';


### PR DESCRIPTION
Related issue:
#392 

Cause:
Wrong coingeckoKey in store leads to incorrect price
Default coingeckoKey doesn't override custom key

Solution:
Prioritize default coingeckoKey, custom key isn't used much by users anyway