### PR TITLE
[Issue-206] Total Balance was wrong due to DOT Crowd loan for Acala & Parallel Token Price was wrong

### DIFF
--- a/packages/extension-koni-ui/src/util/chainBalancesApi.tsx
+++ b/packages/extension-koni-ui/src/util/chainBalancesApi.tsx
@@ -133,7 +133,7 @@ export const getBalances = ({ balance,
 
 function getTokenPrice (tokenPriceMap: Record<string, number>, token: string): number {
   if (token === 'LCDOT') {
-    return (tokenPriceMap.dot || 0) * 0.6925;
+    return 0;
   }
 
   return tokenPriceMap[token.toLowerCase()] || 0;


### PR DESCRIPTION
- #206 

### Is your feature request related to a problem? Please describe.

- Fix Total Balance was wrong due to DOT Crowd loan for Acala
- Parallel Token Price was wrong

### Describe the solution you'd like
- Ignore LCDOT token price
- Don't update coinGeckoKey for token if parachain not launch
### Describe alternatives you've considered

- No

### Additional context

- No