### PR TITLE
[Issue-254] Add feature to allow first-time users to import their Metamask private keys

### DIFF
--- a/packages/extension-koni-ui/src/Popup/Accounts/AddAccount.tsx
+++ b/packages/extension-koni-ui/src/Popup/Accounts/AddAccount.tsx
@@ -86,6 +86,18 @@ function AddAccount ({ className }: Props): React.ReactElement<Props> {
           >
             <Link
               className='add-account-link'
+              to='/account/import-metamask-private-key'
+            >
+              {t<string>('Import private key from MetaMask')}
+            </Link>
+          </Button>
+
+          <Button
+            className='add-account-btn'
+            data-export-button
+          >
+            <Link
+              className='add-account-link'
               onClick={isPopup && (isFirefox || isLinux) ? _openJson : undefined}
               to={isPopup && (isFirefox || isLinux) ? undefined : jsonPath}
             >


### PR DESCRIPTION
### Related issue

- #254 

### Is your feature request related to a problem? Please describe.

- Add feature to allow first-time users to import their Metamask private keys

### Describe the solution you'd like

- Add button `Import private key from Metamask` in `AddAccount` screen

### Describe alternatives you've considered

- No

### Additional context

- No