### PR TITLE
[Issue-584] Can't view Transaction history of Moonbase Alpha network

### DIFF
--- a/packages/extension-koni-ui/src/util/index.ts
+++ b/packages/extension-koni-ui/src/util/index.ts
@@ -232,7 +232,7 @@ export function isSupportScanExplorer (networkKey: string): boolean {
 }
 
 export function getScanExplorerTransactionHistoryUrl (networkKey: string, hash: string, useSubscan?: boolean): string {
-  if (useSubscan) {
+  if (useSubscan && subscanByNetworkKey[networkKey]) {
     return `${subscanByNetworkKey[networkKey]}/extrinsic/${hash}`;
   }
 


### PR DESCRIPTION
### Related issue(s)

- #584

### Is your feature request related to a problem(s)? Please describe.

- Fix cannot open history in moonbase

### Describe the solution you'd like

- Fix `undefined` url subscan 

### Describe alternatives you've considered

- No

### Additional context

- No
