### PR TITLE
[Issue-1139] UpgradeUI - Show counter of accounts to which the master password needs to be applied is incorrect

### DIFF
--- a/packages/extension-koni-ui/src/Popup/Keyring/ApplyMasterPassword/index.tsx
+++ b/packages/extension-koni-ui/src/Popup/Keyring/ApplyMasterPassword/index.tsx
@@ -98,9 +98,13 @@ const Component: React.FC<Props> = (props: Props) => {
   const [loading, setLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
+  const [migrated] = useState(accounts.filter((acc) => acc.address !== ALL_ACCOUNT_KEY && !acc.isExternal && acc.isMasterPassword));
+
   const canMigrate = useMemo(
-    () => accounts.filter((acc) => acc.address !== ALL_ACCOUNT_KEY && !acc.isExternal)
-    , [accounts]
+    () => accounts
+      .filter((acc) => acc.address !== ALL_ACCOUNT_KEY && !acc.isExternal)
+      .filter((acc) => !migrated.find((item) => item.address === acc.address))
+    , [accounts, migrated]
   );
 
   const needMigrate = useMemo(

--- a/packages/extension-koni-ui/src/Popup/Settings/Security/ManageWebsiteAccess/Detail.tsx
+++ b/packages/extension-koni-ui/src/Popup/Settings/Security/ManageWebsiteAccess/Detail.tsx
@@ -262,8 +262,6 @@ function WrapperComponent (props: WrapperProps) {
 
 const ManageWebsiteAccessDetail = styled(WrapperComponent)<Props>(({ theme: { token } }: Props) => {
   return ({
-    paddingBottom: token.paddingMD,
-
     '.ant-sw-list-section': {
       height: '100%'
     },


### PR DESCRIPTION
### Related issue(s)

- #1139

### Is your feature request related to a problem(s)? Please describe.

- Update counter

### Describe the solution you'd like

- Update counter

### Describe alternatives you've considered

- No

### Additional context

- No
