### PR TITLE
[Issue-1234] Show the alternate title name of Dapp in the Manage website access screen

### DIFF
--- a/packages/extension-koni-ui/src/Popup/Settings/Security/ManageWebsiteAccess/Detail.tsx
+++ b/packages/extension-koni-ui/src/Popup/Settings/Security/ManageWebsiteAccess/Detail.tsx
@@ -207,7 +207,7 @@ function Component ({ accountAuthType, authInfo, className = '', goBack, origin,
             onClick: onOpenActionModal
           }
         ]}
-        title={siteName}
+        title={siteName || authInfo.id}
       >
         <SwList.Section
           displayRow


### PR DESCRIPTION
### Related issue(s)

- #1234

### Is your feature request related to a problem(s)? Please describe.

- Display id if site empty

### Describe the solution you'd like

- Display id if site empty

### Describe alternatives you've considered

- No

### Additional context

- No
