### PR TITLE
[Issue-1394] Fix the "All accounts" on top in the List account (Firefox browser)

### DIFF
--- a/packages/extension-koni-ui/src/components/Layout/parts/SelectAccount/index.tsx
+++ b/packages/extension-koni-ui/src/components/Layout/parts/SelectAccount/index.tsx
@@ -73,7 +73,17 @@ function Component ({ className }: Props): React.ReactElement<Props> {
   const isPopup = useIsPopup();
 
   const accounts = useMemo((): AccountJson[] => {
-    return [..._accounts].sort(funcSortByName);
+    const result = [..._accounts].sort(funcSortByName);
+    const all = result.find((acc) => isAccountAll(acc.address));
+
+    if (all) {
+      const index = result.indexOf(all);
+
+      result.splice(index, 1);
+      result.unshift(all);
+    }
+
+    return result;
   }, [_accounts]);
 
   const noAllAccounts = useMemo(() => {


### PR DESCRIPTION
### Related issue(s)

- #1394

### Is your feature request related to a problem(s)? Please describe.

- Rearrange the position of `All accounts`

### Describe the solution you'd like

- Rearrange the position of `All accounts`

### Describe alternatives you've considered

- No

### Additional context

- No
