### PR TITLE
[Issue-1560] Allow user download seed phrase file; [Issue-1229] Resolve problems with expand view

### DIFF
--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -1,7 +1,7 @@
 // Copyright 2019-2022 @polkadot/extension-base authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-const ALLOWED_PATH = ['/', '/settings/security', '/accounts/connect-ledger', '/accounts/restore-json'] as const;
+const ALLOWED_PATH = ['/', '/settings/security', '/accounts/connect-ledger', '/accounts/restore-json', '/accounts/new-seed-phrase'] as const;
 const PHISHING_PAGE_REDIRECT = '/phishing-page-detected';
 const EXTENSION_PREFIX = process.env.EXTENSION_PREFIX as string || '';
 const PORT_MOBILE = `${EXTENSION_PREFIX}mobile`;

--- a/packages/extension-base/src/koni/background/handlers/State.ts
+++ b/packages/extension-base/src/koni/background/handlers/State.ts
@@ -1580,6 +1580,15 @@ export default class KoniState {
   public onInstall () {
     const singleModes = Object.values(_PREDEFINED_SINGLE_MODES);
 
+    try {
+      // Open expand page
+      const url = `${chrome.extension.getURL('index.html')}#/`;
+
+      withErrorLog(() => chrome.tabs.create({ url }));
+    } catch (e) {
+      console.error(e);
+    }
+
     const setUpSingleMode = ({ networkKeys, theme }: SingleModeJson) => {
       networkKeys.forEach((key) => {
         this.enableChain(key).catch(console.error);

--- a/packages/extension-koni-ui/src/Popup/Account/ImportSeedPhrase.tsx
+++ b/packages/extension-koni-ui/src/Popup/Account/ImportSeedPhrase.tsx
@@ -4,7 +4,7 @@
 import { Layout, PageWrapper } from '@subwallet/extension-koni-ui/components';
 import SelectAccountType from '@subwallet/extension-koni-ui/components/Account/SelectAccountType';
 import CloseIcon from '@subwallet/extension-koni-ui/components/Icon/CloseIcon';
-import { EVM_ACCOUNT_TYPE, SUBSTRATE_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants/account';
+import { DEFAULT_ACCOUNT_TYPES } from '@subwallet/extension-koni-ui/constants/account';
 import { IMPORT_ACCOUNT_MODAL } from '@subwallet/extension-koni-ui/constants/modal';
 import useCompleteCreateAccount from '@subwallet/extension-koni-ui/hooks/account/useCompleteCreateAccount';
 import useGetDefaultAccountName from '@subwallet/extension-koni-ui/hooks/account/useGetDefaultAccountName';
@@ -50,7 +50,7 @@ const Component: React.FC<Props> = ({ className }: Props) => {
 
   const [form] = Form.useForm();
 
-  const [keyTypes, setKeyTypes] = useState<KeypairType[]>([SUBSTRATE_ACCOUNT_TYPE, EVM_ACCOUNT_TYPE]);
+  const [keyTypes, setKeyTypes] = useState<KeypairType[]>(DEFAULT_ACCOUNT_TYPES);
   const [validateState, setValidateState] = useState<ValidateState>({});
   const [validating, setValidating] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -110,7 +110,7 @@ const Component: React.FC<Props> = ({ className }: Props) => {
         });
 
         timeOutRef.current = setTimeout(() => {
-          validateSeedV2(seed, [SUBSTRATE_ACCOUNT_TYPE, EVM_ACCOUNT_TYPE])
+          validateSeedV2(seed, DEFAULT_ACCOUNT_TYPES)
             .then((res) => {
               if (amount) {
                 setValidateState({});

--- a/packages/extension-koni-ui/src/Popup/Account/NewSeedPhrase.tsx
+++ b/packages/extension-koni-ui/src/Popup/Account/NewSeedPhrase.tsx
@@ -4,26 +4,27 @@
 import { Layout, PageWrapper } from '@subwallet/extension-koni-ui/components';
 import CloseIcon from '@subwallet/extension-koni-ui/components/Icon/CloseIcon';
 import WordPhrase from '@subwallet/extension-koni-ui/components/WordPhrase';
-import { EVM_ACCOUNT_TYPE, SUBSTRATE_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants/account';
+import { DEFAULT_ACCOUNT_TYPES, SELECTED_CREATE_ACCOUNT_TYPE_KEY } from '@subwallet/extension-koni-ui/constants/account';
 import { NEW_ACCOUNT_MODAL } from '@subwallet/extension-koni-ui/constants/modal';
 import { DEFAULT_ROUTER_PATH } from '@subwallet/extension-koni-ui/constants/router';
+import { useIsPopup } from '@subwallet/extension-koni-ui/hooks';
 import useCompleteCreateAccount from '@subwallet/extension-koni-ui/hooks/account/useCompleteCreateAccount';
 import useGetDefaultAccountName from '@subwallet/extension-koni-ui/hooks/account/useGetDefaultAccountName';
 import useNotification from '@subwallet/extension-koni-ui/hooks/common/useNotification';
 import useTranslation from '@subwallet/extension-koni-ui/hooks/common/useTranslation';
 import useAutoNavigateToCreatePassword from '@subwallet/extension-koni-ui/hooks/router/useAutoNavigateToCreatePassword';
 import useDefaultNavigate from '@subwallet/extension-koni-ui/hooks/router/useDefaultNavigate';
-import { createAccountSuriV2, createSeedV2 } from '@subwallet/extension-koni-ui/messaging';
+import { createAccountSuriV2, createSeedV2, windowOpen } from '@subwallet/extension-koni-ui/messaging';
 import { RootState } from '@subwallet/extension-koni-ui/stores';
 import { ThemeProps } from '@subwallet/extension-koni-ui/types';
-import { NewSeedPhraseState } from '@subwallet/extension-koni-ui/types/account';
+import { isFirefox } from '@subwallet/extension-koni-ui/utils';
 import { isNoAccount } from '@subwallet/extension-koni-ui/utils/account/account';
 import { Icon, ModalContext } from '@subwallet/react-ui';
 import CN from 'classnames';
 import { CheckCircle } from 'phosphor-react';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { KeypairType } from '@polkadot/util-crypto/types';
@@ -40,7 +41,6 @@ const FooterIcon = (
 const Component: React.FC<Props> = ({ className }: Props) => {
   useAutoNavigateToCreatePassword();
   const { t } = useTranslation();
-  const location = useLocation();
   const notify = useNotification();
   const navigate = useNavigate();
 
@@ -49,9 +49,17 @@ const Component: React.FC<Props> = ({ className }: Props) => {
 
   const onComplete = useCompleteCreateAccount();
   const accountName = useGetDefaultAccountName();
+  const isPopup = useIsPopup();
 
-  const { accounts } = useSelector((state: RootState) => state.accountState);
-  const [accountTypes] = useState<KeypairType[]>((location.state as NewSeedPhraseState)?.accountTypes || []);
+  const { accounts, hasMasterPassword } = useSelector((state: RootState) => state.accountState);
+
+  const isOpenWindowRef = useRef(false);
+
+  const [accountTypes] = useState<KeypairType[]>(() => {
+    const storage = localStorage.getItem(SELECTED_CREATE_ACCOUNT_TYPE_KEY);
+
+    return storage ? JSON.parse(storage) as KeypairType[] : DEFAULT_ACCOUNT_TYPES;
+  });
 
   const [seedPhrase, setSeedPhrase] = useState('');
   const [loading, setLoading] = useState(false);
@@ -96,7 +104,7 @@ const Component: React.FC<Props> = ({ className }: Props) => {
   }, [seedPhrase, accountName, accountTypes, onComplete, notify]);
 
   useEffect(() => {
-    createSeedV2(undefined, undefined, [SUBSTRATE_ACCOUNT_TYPE, EVM_ACCOUNT_TYPE])
+    createSeedV2(undefined, undefined, DEFAULT_ACCOUNT_TYPES)
       .then((response): void => {
         const phrase = response.seed;
 
@@ -106,6 +114,13 @@ const Component: React.FC<Props> = ({ className }: Props) => {
         console.error(e);
       });
   }, []);
+
+  useEffect(() => {
+    if (isPopup && isFirefox() && hasMasterPassword && !isOpenWindowRef.current) {
+      isOpenWindowRef.current = true;
+      windowOpen('/accounts/new-seed-phrase').then(window.close).catch(console.log);
+    }
+  }, [isPopup, hasMasterPassword]);
 
   return (
     <PageWrapper
@@ -133,7 +148,10 @@ const Component: React.FC<Props> = ({ className }: Props) => {
           <div className='description'>
             {t('Keep your recovery phrase in a safe place and never disclose it. Anyone with this phrase can take control of your assets.')}
           </div>
-          <WordPhrase seedPhrase={seedPhrase} />
+          <WordPhrase
+            enableDownload={true}
+            seedPhrase={seedPhrase}
+          />
         </div>
       </Layout.WithSubHeaderOnly>
     </PageWrapper>

--- a/packages/extension-koni-ui/src/Popup/Confirmations/variants/AuthorizeConfirmation.tsx
+++ b/packages/extension-koni-ui/src/Popup/Confirmations/variants/AuthorizeConfirmation.tsx
@@ -4,7 +4,7 @@
 import { AccountAuthType, AccountJson, AuthorizeRequest } from '@subwallet/extension-base/background/types';
 import { ALL_ACCOUNT_KEY } from '@subwallet/extension-base/constants';
 import { AccountItemWithName, ConfirmationGeneralInfo } from '@subwallet/extension-koni-ui/components';
-import { EVM_ACCOUNT_TYPE, SUBSTRATE_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants';
+import { DEFAULT_ACCOUNT_TYPES, EVM_ACCOUNT_TYPE, SUBSTRATE_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants';
 import { approveAuthRequestV2, cancelAuthRequestV2, rejectAuthRequestV2 } from '@subwallet/extension-koni-ui/messaging';
 import { RootState } from '@subwallet/extension-koni-ui/stores';
 import { ThemeProps } from '@subwallet/extension-koni-ui/types';
@@ -124,7 +124,7 @@ function Component ({ className, request }: Props) {
         types = [EVM_ACCOUNT_TYPE];
         break;
       default:
-        types = [SUBSTRATE_ACCOUNT_TYPE, EVM_ACCOUNT_TYPE];
+        types = DEFAULT_ACCOUNT_TYPES;
     }
 
     navigate('/accounts/new-seed-phrase', { state: { accountTypes: types } });

--- a/packages/extension-koni-ui/src/Popup/CreateDone.tsx
+++ b/packages/extension-koni-ui/src/Popup/CreateDone.tsx
@@ -1,50 +1,18 @@
 // Copyright 2019-2022 @subwallet/extension-koni-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { DISCORD_URL, TELEGRAM_URL, TWITTER_URL } from '@subwallet/extension-koni-ui/constants/common';
 import useDefaultNavigate from '@subwallet/extension-koni-ui/hooks/router/useDefaultNavigate';
-import { PhosphorIcon, ThemeProps } from '@subwallet/extension-koni-ui/types';
-import { openInNewTab } from '@subwallet/extension-koni-ui/utils';
-import { Button, Icon, PageIcon } from '@subwallet/react-ui';
+import { ThemeProps } from '@subwallet/extension-koni-ui/types';
+import { Icon, PageIcon } from '@subwallet/react-ui';
 import CN from 'classnames';
-import { ArrowCircleRight, CheckCircle, DiscordLogo, PaperPlaneTilt, TwitterLogo, X } from 'phosphor-react';
+import { ArrowCircleRight, CheckCircle, X } from 'phosphor-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import { Layout } from '../components';
+import { Layout, SocialButtonGroup } from '../components';
 
 type Props = ThemeProps;
-
-enum SocialType {
-  TWITTER = 'twitter',
-  DISCORD = 'discord',
-  TELEGRAM = 'telegram',
-}
-
-interface SocialItem {
-  icon: PhosphorIcon;
-  type: SocialType;
-  url: string;
-}
-
-const items: SocialItem[] = [
-  {
-    icon: TwitterLogo,
-    type: SocialType.TWITTER,
-    url: TWITTER_URL
-  },
-  {
-    icon: DiscordLogo,
-    type: SocialType.DISCORD,
-    url: DISCORD_URL
-  },
-  {
-    icon: PaperPlaneTilt,
-    type: SocialType.TELEGRAM,
-    url: TELEGRAM_URL
-  }
-];
 
 const Component: React.FC<Props> = (props: Props) => {
   const { className } = props;
@@ -88,30 +56,13 @@ const Component: React.FC<Props> = (props: Props) => {
         <div className='description'>
           {t('Follow along with product updates or reach out if you have any questions.')}
         </div>
-        <div className='button-group'>
-          {
-            items.map((item) => (
-              <Button
-                className={CN(`type-${item.type}`)}
-                icon={(
-                  <Icon
-                    phosphorIcon={item.icon}
-                    weight='fill'
-                  />
-                )}
-                key={item.type}
-                onClick={openInNewTab(item.url)}
-                shape='squircle'
-              />
-            ))
-          }
-        </div>
+        <SocialButtonGroup />
       </div>
     </Layout.WithSubHeaderOnly>
   );
 };
 
-const CreatePasswordDone = styled(Component)<Props>(({ theme: { token } }: Props) => {
+const CreateDone = styled(Component)<Props>(({ theme: { token } }: Props) => {
   return {
     textAlign: 'center',
 
@@ -140,40 +91,8 @@ const CreatePasswordDone = styled(Component)<Props>(({ theme: { token } }: Props
       lineHeight: token.lineHeightHeading5,
       color: token.colorTextDescription,
       textAlign: 'center'
-    },
-
-    '.button-group': {
-      display: 'flex',
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: token.size
-    },
-
-    [`.type-${SocialType.TWITTER}`]: {
-      backgroundColor: token['blue-7'],
-
-      '&:hover': {
-        backgroundColor: token['blue-8']
-      }
-    },
-
-    [`.type-${SocialType.DISCORD}`]: {
-      backgroundColor: token['geekblue-8'],
-
-      '&:hover': {
-        backgroundColor: token['geekblue-9']
-      }
-    },
-
-    [`.type-${SocialType.TELEGRAM}`]: {
-      backgroundColor: token['blue-5'],
-
-      '&:hover': {
-        backgroundColor: token['blue-6']
-      }
     }
   };
 });
 
-export default CreatePasswordDone;
+export default CreateDone;

--- a/packages/extension-koni-ui/src/Popup/Root.tsx
+++ b/packages/extension-koni-ui/src/Popup/Root.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ALL_ACCOUNT_KEY } from '@subwallet/extension-base/constants';
-import { PageWrapper } from '@subwallet/extension-koni-ui/components';
+import { BackgroundExpandView, PageWrapper } from '@subwallet/extension-koni-ui/components';
 import Logo2D from '@subwallet/extension-koni-ui/components/Logo/Logo2D';
 import { DEFAULT_ROUTER_PATH } from '@subwallet/extension-koni-ui/constants/router';
 import { DataContext } from '@subwallet/extension-koni-ui/contexts/DataContext';
@@ -44,9 +44,10 @@ function DefaultRoute ({ children }: {children: React.ReactNode}): React.ReactEl
   const navigate = useNavigate();
   const { goBack, goHome } = useDefaultNavigate();
   const { isOpenPModal, openPModal } = usePredefinedModal();
+  const notify = useNotification();
+
   const { hasConfirmations, hasInternalConfirmations } = useSelector((state: RootState) => state.requestState);
   const { accounts, hasMasterPassword, isLocked } = useSelector((state: RootState) => state.accountState);
-  const notify = useNotification();
 
   const needMigrate = useMemo(
     () => !!accounts
@@ -134,7 +135,9 @@ function DefaultRoute ({ children }: {children: React.ReactNode}): React.ReactEl
     }
   }, [accounts, goBack, goHome, hasConfirmations, hasInternalConfirmations, hasMasterPassword, isLocked, isOpenPModal, location.pathname, navigate, needMigrate, openPModal]);
 
-  return <>{children}</>;
+  return <>
+    {children}
+  </>;
 }
 
 const Main = styled.main`
@@ -160,6 +163,7 @@ function _Root ({ className }: ThemeProps): React.ReactElement {
           </Main>
         </DefaultRoute>
       </PageWrapper>
+      <BackgroundExpandView />
     </WalletModalContext>
   );
 }

--- a/packages/extension-koni-ui/src/Popup/Welcome.tsx
+++ b/packages/extension-koni-ui/src/Popup/Welcome.tsx
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Layout } from '@subwallet/extension-koni-ui/components';
-import { EVM_ACCOUNT_TYPE, SUBSTRATE_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants/account';
+import { DEFAULT_ACCOUNT_TYPES } from '@subwallet/extension-koni-ui/constants';
 import { ATTACH_ACCOUNT_MODAL, CREATE_ACCOUNT_MODAL, IMPORT_ACCOUNT_MODAL, SELECT_ACCOUNT_MODAL } from '@subwallet/extension-koni-ui/constants/modal';
 import useTranslation from '@subwallet/extension-koni-ui/hooks/common/useTranslation';
 import { PhosphorIcon, ThemeProps } from '@subwallet/extension-koni-ui/types';
+import { setSelectedAccountTypes } from '@subwallet/extension-koni-ui/utils';
 import { Button, ButtonProps, Icon, Image, ModalContext } from '@subwallet/react-ui';
 import CN from 'classnames';
 import { FileArrowDown, PlusCircle, Swatches } from 'phosphor-react';
@@ -55,7 +56,8 @@ function Component ({ className }: Props): React.ReactElement<Props> {
   const openModal = useCallback((id: string) => {
     return () => {
       if (id === CREATE_ACCOUNT_MODAL) {
-        navigate('/accounts/new-seed-phrase', { state: { accountTypes: [SUBSTRATE_ACCOUNT_TYPE, EVM_ACCOUNT_TYPE] } });
+        setSelectedAccountTypes(DEFAULT_ACCOUNT_TYPES);
+        navigate('/accounts/new-seed-phrase');
       } else {
         inactiveModal(SELECT_ACCOUNT_MODAL);
         activeModal(id);

--- a/packages/extension-koni-ui/src/components/BackgroundExpandView.tsx
+++ b/packages/extension-koni-ui/src/components/BackgroundExpandView.tsx
@@ -3,7 +3,7 @@
 
 import { useIsPopup } from '@subwallet/extension-koni-ui/hooks';
 import { ThemeProps } from '@subwallet/extension-koni-ui/types';
-import { convertHexColorToRGBA } from '@subwallet/extension-koni-ui/utils';
+import { convertHexColorToRGBA, openInNewTab } from '@subwallet/extension-koni-ui/utils';
 import { Button, Icon } from '@subwallet/react-ui';
 import CN from 'classnames';
 import { Question } from 'phosphor-react';
@@ -32,7 +32,7 @@ const Component: React.FC<Props> = (props: Props) => {
     return !['/create-done'].includes(pathName);
   }, [location.pathname]);
 
-  const isNoti = useMemo(() => {
+  const isShowNotification = useMemo(() => {
     const pathName = location.pathname;
 
     return ['/create-done'].includes(pathName);
@@ -51,6 +51,7 @@ const Component: React.FC<Props> = (props: Props) => {
         <div className='help-container'>
           <Button
             icon={<Icon phosphorIcon={Question} />}
+            onClick={openInNewTab('https://docs.subwallet.app/')}
             size='xs'
             type='ghost'
           >
@@ -58,7 +59,7 @@ const Component: React.FC<Props> = (props: Props) => {
           </Button>
         </div>
         {
-          isNoti && (
+          isShowNotification && (
             <div className='message-container'>
               <PinExtensionMessage />
             </div>

--- a/packages/extension-koni-ui/src/components/BackgroundExpandView.tsx
+++ b/packages/extension-koni-ui/src/components/BackgroundExpandView.tsx
@@ -1,0 +1,126 @@
+// Copyright 2019-2022 @subwallet/extension-koni-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useIsPopup } from '@subwallet/extension-koni-ui/hooks';
+import { ThemeProps } from '@subwallet/extension-koni-ui/types';
+import { convertHexColorToRGBA } from '@subwallet/extension-koni-ui/utils';
+import { Button, Icon } from '@subwallet/react-ui';
+import CN from 'classnames';
+import { Question } from 'phosphor-react';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { Logo2D } from './Logo';
+import PinExtensionMessage from './PinExtensionMessage';
+import SocialButtonGroup from './SocialButtonGroup';
+
+type Props = ThemeProps;
+
+const Component: React.FC<Props> = (props: Props) => {
+  const { className } = props;
+
+  const { t } = useTranslation();
+  const location = useLocation();
+
+  const isPopup = useIsPopup();
+
+  const isShowFooter = useMemo(() => {
+    const pathName = location.pathname;
+
+    return !['/create-done'].includes(pathName);
+  }, [location.pathname]);
+
+  const isNoti = useMemo(() => {
+    const pathName = location.pathname;
+
+    return ['/create-done'].includes(pathName);
+  }, [location.pathname]);
+
+  if (isPopup) {
+    return null;
+  }
+
+  return (
+    <div className={CN(className)}>
+      <div className='expand-view-header'>
+        <div className='logo-container'>
+          <Logo2D />
+        </div>
+        <div className='help-container'>
+          <Button
+            icon={<Icon phosphorIcon={Question} />}
+            size='xs'
+            type='ghost'
+          >
+            {t('Help')}
+          </Button>
+        </div>
+        {
+          isNoti && (
+            <div className='message-container'>
+              <PinExtensionMessage />
+            </div>
+          )
+        }
+      </div>
+      {
+        isShowFooter && (
+          <div className='expand-view-footer'>
+            <SocialButtonGroup />
+          </div>
+        )
+      }
+    </div>
+  );
+};
+
+const BackgroundExpandView = styled(Component)<Props>(({ theme: { token } }: Props) => {
+  return {
+    width: '100%',
+    height: '100%',
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    zIndex: -1,
+
+    '.expand-view-header': {
+      height: 331,
+      background: `linear-gradient(180deg, ${convertHexColorToRGBA(token.colorPrimary, 0.1)} 17.49%, ${convertHexColorToRGBA(token['gray-6'], 0)} 100%)`
+    },
+
+    '.logo-container': {
+      position: 'fixed',
+      left: token.sizeLG,
+      top: token.sizeXL - 1,
+      color: token.colorWhite
+    },
+
+    '.help-container': {
+      position: 'fixed',
+      right: token.sizeLG,
+      top: token.sizeLG,
+
+      '.ant-btn': {
+        padding: 0
+      }
+    },
+
+    '.message-container': {
+      position: 'fixed',
+      right: token.sizeMD,
+      top: token.sizeMD
+    },
+
+    '.expand-view-footer': {
+      position: 'fixed',
+      width: '100%',
+      bottom: token.controlHeightLG,
+      left: '0',
+      zIndex: -1
+    }
+  };
+});
+
+export default BackgroundExpandView;

--- a/packages/extension-koni-ui/src/components/Modal/Account/NewAccountModal.tsx
+++ b/packages/extension-koni-ui/src/components/Modal/Account/NewAccountModal.tsx
@@ -4,12 +4,13 @@
 import SelectAccountType from '@subwallet/extension-koni-ui/components/Account/SelectAccountType';
 import BackIcon from '@subwallet/extension-koni-ui/components/Icon/BackIcon';
 import CloseIcon from '@subwallet/extension-koni-ui/components/Icon/CloseIcon';
-import { EVM_ACCOUNT_TYPE, SUBSTRATE_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants/account';
+import { DEFAULT_ACCOUNT_TYPES } from '@subwallet/extension-koni-ui/constants/account';
 import { CREATE_ACCOUNT_MODAL, NEW_ACCOUNT_MODAL } from '@subwallet/extension-koni-ui/constants/modal';
 import useTranslation from '@subwallet/extension-koni-ui/hooks/common/useTranslation';
 import useClickOutSide from '@subwallet/extension-koni-ui/hooks/dom/useClickOutSide';
 import useSwitchModal from '@subwallet/extension-koni-ui/hooks/modal/useSwitchModal';
 import { ThemeProps } from '@subwallet/extension-koni-ui/types';
+import { setSelectedAccountTypes } from '@subwallet/extension-koni-ui/utils';
 import { renderModalSelector } from '@subwallet/extension-koni-ui/utils/common/dom';
 import { Button, Icon, ModalContext, SwModal } from '@subwallet/react-ui';
 import CN from 'classnames';
@@ -24,22 +25,21 @@ type Props = ThemeProps;
 
 const modalId = NEW_ACCOUNT_MODAL;
 
-const defaultSelectedTypes = [SUBSTRATE_ACCOUNT_TYPE, EVM_ACCOUNT_TYPE];
-
 const Component: React.FC<Props> = ({ className }: Props) => {
   const { t } = useTranslation();
   const { checkActive, inactiveModal } = useContext(ModalContext);
   const navigate = useNavigate();
   const isActive = checkActive(modalId);
 
-  const [selectedItems, setSelectedItems] = useState<KeypairType[]>(defaultSelectedTypes);
+  const [selectedItems, setSelectedItems] = useState<KeypairType[]>(DEFAULT_ACCOUNT_TYPES);
 
   const onCancel = useCallback(() => {
     inactiveModal(modalId);
   }, [inactiveModal]);
 
   const onSubmit = useCallback(() => {
-    navigate('/accounts/new-seed-phrase', { state: { accountTypes: selectedItems } });
+    setSelectedAccountTypes(selectedItems);
+    navigate('/accounts/new-seed-phrase');
     inactiveModal(modalId);
   }, [navigate, selectedItems, inactiveModal]);
 
@@ -49,7 +49,7 @@ const Component: React.FC<Props> = ({ className }: Props) => {
 
   useEffect(() => {
     if (!isActive) {
-      setSelectedItems(defaultSelectedTypes);
+      setSelectedItems(DEFAULT_ACCOUNT_TYPES);
     }
   }, [isActive]);
 

--- a/packages/extension-koni-ui/src/components/PinExtensionMessage.tsx
+++ b/packages/extension-koni-ui/src/components/PinExtensionMessage.tsx
@@ -1,0 +1,88 @@
+// Copyright 2019-2022 @subwallet/extension-koni-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { ThemeProps } from '@subwallet/extension-koni-ui/types';
+import { Icon, Image } from '@subwallet/react-ui';
+import CN from 'classnames';
+import { PushPinSimple, PuzzlePiece } from 'phosphor-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+type Props = ThemeProps;
+
+const Component: React.FC<Props> = (props: Props) => {
+  const { className } = props;
+
+  const { t } = useTranslation();
+
+  return (
+    <div className={CN(className)}>
+      <div className='message-header'>
+        <div className='message-image'>
+          <Image
+            height='var(--img-height)'
+            shape='square'
+            src='/images/subwallet/gradient-logo.png'
+          />
+        </div>
+        <div className='message-content'>
+          {t('Pin SubWallet to toolbar for easier access')}
+        </div>
+      </div>
+      <div className='message-sub-content'>
+        <span>Click&nbsp;</span>
+        <Icon
+          phosphorIcon={PuzzlePiece}
+          size='sm'
+          weight='fill'
+        />
+        <span>&nbsp;select SubWallet and then&nbsp;</span>
+        <Icon
+          phosphorIcon={PushPinSimple}
+          size='sm'
+          weight='fill'
+        />
+      </div>
+    </div>
+  );
+};
+
+const PinExtensionMessage = styled(Component)<Props>(({ theme: { token } }: Props) => {
+  return {
+    width: token.sizeXL * 10,
+    borderRadius: token.borderRadiusLG,
+    padding: `${token.padding}px ${token.paddingXL - 2}px`,
+    borderWidth: token.lineWidth,
+    borderStyle: token.lineType,
+    borderColor: '#333333', // TODO: Need add color to UI lib
+    backgroundColor: token.colorTextDark2,
+
+    '.message-header': {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: token.size
+    },
+
+    '.message-image': {
+      '--img-height': token.sizeXL
+    },
+
+    '.message-content': {
+      fontSize: token.fontSizeHeading5,
+      lineHeight: token.lineHeightHeading5
+    },
+
+    '.message-sub-content': {
+      fontSize: token.fontSizeHeading6,
+      lineHeight: token.lineHeightHeading6,
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginTop: token.marginSM
+    }
+  };
+});
+
+export default PinExtensionMessage;

--- a/packages/extension-koni-ui/src/components/SocialButtonGroup.tsx
+++ b/packages/extension-koni-ui/src/components/SocialButtonGroup.tsx
@@ -1,0 +1,106 @@
+// Copyright 2019-2022 @subwallet/extension-koni-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { DISCORD_URL, TELEGRAM_URL, TWITTER_URL } from '@subwallet/extension-koni-ui/constants';
+import { PhosphorIcon, ThemeProps } from '@subwallet/extension-koni-ui/types';
+import { openInNewTab } from '@subwallet/extension-koni-ui/utils';
+import { Button, Icon } from '@subwallet/react-ui';
+import CN from 'classnames';
+import { DiscordLogo, PaperPlaneTilt, TwitterLogo } from 'phosphor-react';
+import React from 'react';
+import styled from 'styled-components';
+
+type Props = ThemeProps;
+
+enum SocialType {
+  TWITTER = 'twitter',
+  DISCORD = 'discord',
+  TELEGRAM = 'telegram',
+}
+
+interface SocialItem {
+  icon: PhosphorIcon;
+  type: SocialType;
+  url: string;
+}
+
+const items: SocialItem[] = [
+  {
+    icon: TwitterLogo,
+    type: SocialType.TWITTER,
+    url: TWITTER_URL
+  },
+  {
+    icon: DiscordLogo,
+    type: SocialType.DISCORD,
+    url: DISCORD_URL
+  },
+  {
+    icon: PaperPlaneTilt,
+    type: SocialType.TELEGRAM,
+    url: TELEGRAM_URL
+  }
+];
+
+const Component: React.FC<Props> = (props: Props) => {
+  const { className } = props;
+
+  return (
+    <div className={CN(className, 'button-group')}>
+      {
+        items.map((item) => (
+          <Button
+            className={CN(`type-${item.type}`)}
+            icon={(
+              <Icon
+                phosphorIcon={item.icon}
+                weight='fill'
+              />
+            )}
+            key={item.type}
+            onClick={openInNewTab(item.url)}
+            shape='squircle'
+          />
+        ))
+      }
+    </div>
+  );
+};
+
+const SocialButtonGroup = styled(Component)<Props>(({ theme: { token } }: Props) => {
+  return {
+    '&.button-group': {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: token.size
+    },
+
+    [`.type-${SocialType.TWITTER}`]: {
+      backgroundColor: token['blue-7'],
+
+      '&:hover': {
+        backgroundColor: token['blue-8']
+      }
+    },
+
+    [`.type-${SocialType.DISCORD}`]: {
+      backgroundColor: token['geekblue-8'],
+
+      '&:hover': {
+        backgroundColor: token['geekblue-9']
+      }
+    },
+
+    [`.type-${SocialType.TELEGRAM}`]: {
+      backgroundColor: token['blue-5'],
+
+      '&:hover': {
+        backgroundColor: token['blue-6']
+      }
+    }
+  };
+});
+
+export default SocialButtonGroup;

--- a/packages/extension-koni-ui/src/components/WordPhrase.tsx
+++ b/packages/extension-koni-ui/src/components/WordPhrase.tsx
@@ -7,23 +7,39 @@ import { WordItem } from '@subwallet/extension-koni-ui/types/account';
 import { convertToWords } from '@subwallet/extension-koni-ui/utils/account/seedPhrase';
 import { Button, Icon } from '@subwallet/react-ui';
 import CN from 'classnames';
+import { saveAs } from 'file-saver';
 import { CopySimple } from 'phosphor-react';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 interface Props extends ThemeProps {
   seedPhrase: string;
+  enableDownload?: boolean;
 }
 
 const Component: React.FC<Props> = (props: Props) => {
-  const { className, seedPhrase } = props;
+  const { className, enableDownload, seedPhrase } = props;
 
   const { t } = useTranslation();
 
   const words: Array<Array<WordItem>> = useMemo(() => convertToWords(seedPhrase), [seedPhrase]);
 
   const onCopy = useCopy(seedPhrase);
+
+  const backupMnemonicSeed = useCallback(() => {
+    const blob = new Blob([seedPhrase], { type: 'text/plain' });
+
+    saveAs(blob, 'mnemonic-seed.txt');
+  }, [seedPhrase]);
+
+  const onClick = useCallback(() => {
+    onCopy();
+
+    if (enableDownload) {
+      backupMnemonicSeed();
+    }
+  }, [backupMnemonicSeed, enableDownload, onCopy]);
 
   return (
     <div className={CN(className)}>
@@ -57,7 +73,7 @@ const Component: React.FC<Props> = (props: Props) => {
         icon={(
           <Icon phosphorIcon={CopySimple} />
         )}
-        onClick={onCopy}
+        onClick={onClick}
         type='ghost'
       >
         {t('Copy to clipboard')}

--- a/packages/extension-koni-ui/src/components/WordPhrase.tsx
+++ b/packages/extension-koni-ui/src/components/WordPhrase.tsx
@@ -76,7 +76,7 @@ const Component: React.FC<Props> = (props: Props) => {
         onClick={onClick}
         type='ghost'
       >
-        {t('Copy to clipboard')}
+        {enableDownload ? t('Copy & Save to the clipboard') : t('Copy to clipboard')}
       </Button>
     </div>
   );

--- a/packages/extension-koni-ui/src/components/index.ts
+++ b/packages/extension-koni-ui/src/components/index.ts
@@ -2,14 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { default as AlertBox } from './Alert';
+export { default as BackgroundExpandView } from './BackgroundExpandView';
 export { default as ChainItemFooter } from './ChainItemFooter';
 export { default as EmptyList } from './EmptyList';
 export { default as GeneralEmptyList } from './GeneralEmptyList';
 export { default as LoadingScreen } from './LoadingScreen';
 export { default as NetworkToggleItem } from './NetworkToggleItem';
+export { default as PinExtensionMessage } from './PinExtensionMessage';
 export { default as RadioGroup } from './Field/RadioGroup';
 export { default as ScreenTab } from './ScreenTab';
 export { default as SelectValidatorInput } from './SelectValidatorInput';
+export { default as SocialButtonGroup } from './SocialButtonGroup';
 export { default as WordPhrase } from './WordPhrase';
 
 export * from '../contexts';

--- a/packages/extension-koni-ui/src/constants/account.ts
+++ b/packages/extension-koni-ui/src/constants/account.ts
@@ -5,3 +5,7 @@ import { KeypairType } from '@polkadot/util-crypto/types';
 
 export const SUBSTRATE_ACCOUNT_TYPE: KeypairType = 'sr25519';
 export const EVM_ACCOUNT_TYPE: KeypairType = 'ethereum';
+
+export const DEFAULT_ACCOUNT_TYPES: KeypairType[] = [SUBSTRATE_ACCOUNT_TYPE, EVM_ACCOUNT_TYPE];
+
+export const SELECTED_CREATE_ACCOUNT_TYPE_KEY = 'selectedCreateAccountType';

--- a/packages/extension-koni-ui/src/themes.ts
+++ b/packages/extension-koni-ui/src/themes.ts
@@ -46,7 +46,7 @@ export interface SwThemeConfig extends ThemeConfig {
 
 function genDefaultExtraTokens (token: AliasToken): ExtraToken {
   return {
-    bodyBackgroundColor: token['gray-1'],
+    bodyBackgroundColor: token.colorBgDefault,
     logo: subWalletLogo,
     defaultImagePlaceholder,
     tokensScreenSuccessBackgroundColor: 'linear-gradient(180deg, rgba(76, 234, 172, 0.1) 16.47%, rgba(217, 217, 217, 0) 94.17%)',

--- a/packages/extension-koni-ui/src/utils/common/browser.ts
+++ b/packages/extension-koni-ui/src/utils/common/browser.ts
@@ -1,8 +1,25 @@
 // Copyright 2019-2022 @subwallet/extension-koni-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { SELECTED_CREATE_ACCOUNT_TYPE_KEY } from '@subwallet/extension-koni-ui/constants';
+import Bowser from 'bowser';
+
+import { KeypairType } from '@polkadot/util-crypto/types';
+
 export const openInNewTab = (url: string) => {
   return () => {
     window.open(url, '_blank');
   };
+};
+
+export const getBrowserName = (): string => {
+  return (localStorage.getItem('browserInfo') || Bowser.getParser(window.navigator.userAgent).getBrowserName());
+};
+
+export const isFirefox = (): boolean => {
+  return getBrowserName().toLowerCase() === 'firefox';
+};
+
+export const setSelectedAccountTypes = (keypairTypes: KeypairType[]) => {
+  localStorage.setItem(SELECTED_CREATE_ACCOUNT_TYPE_KEY, JSON.stringify(keypairTypes));
 };


### PR DESCRIPTION
### Related issue(s)

- #1560
- #1229 

### Is your feature request related to a problem(s)? Please describe.

- Add download file action on `Create new seed phrase` screen
- Open expand view after install
- Update UI for expand view

### Describe the solution you'd like

- Add download file action on `Create new seed phrase` screen
- Open expand view after install
- Update UI for expand view

### Describe alternatives you've considered

- No

### Additional context

- No
