### PR TITLE
[Issue-1657] Do not validate amount of the recipient address when send on-chain

### DIFF
--- a/packages/extension-base/src/koni/background/handlers/Extension.ts
+++ b/packages/extension-base/src/koni/background/handlers/Extension.ts
@@ -1641,6 +1641,7 @@ export default class KoniExtension {
     const additionalValidator = async (inputTransaction: SWTransactionResponse): Promise<void> => {
       const minAmount = tokenInfo.minAmount || '0';
 
+      // Check ed for sender
       if (!isTransferNativeToken) {
         const { value: balance } = await this.getAddressFreeBalance({ address: from, networkKey, token: tokenSlug });
 
@@ -1649,8 +1650,9 @@ export default class KoniExtension {
         }
       }
 
-      const { value: receiverBalance } = await this.getAddressFreeBalance({ address: from, networkKey, token: tokenSlug });
+      const { value: receiverBalance } = await this.getAddressFreeBalance({ address: to, networkKey, token: tokenSlug });
 
+      // Check ed for receiver
       if (new BigN(receiverBalance).plus(transferAmount.value).lt(minAmount)) {
         const atLeast = new BigN(minAmount).minus(receiverBalance).plus((tokenInfo.decimals || 0) === 0 ? 0 : 1);
 
@@ -1725,6 +1727,7 @@ export default class KoniExtension {
         const destMinAmount = destinationTokenInfo.minAmount || '0';
         const atLeast = new BigN(destMinAmount).multipliedBy(XCM_MIN_AMOUNT_RATIO);
 
+        // Check ed for receiver
         if (new BigN(value).lt(atLeast)) {
           const atLeastStr = formatNumber(atLeast, destinationTokenInfo.decimals || 0, balanceFormatter);
 
@@ -1734,8 +1737,9 @@ export default class KoniExtension {
         const srcMinAmount = originTokenInfo.minAmount || '0';
         const isTransferNativeToken = originTokenInfo.assetType === _AssetType.NATIVE;
 
+        // Check ed for sender
         if (!isTransferNativeToken) {
-          const { value: balance } = await this.#koniState.balanceService.getTokenFreeBalance(from, originNetworkKey, originTokenInfo.slug);
+          const { value: balance } = await this.getAddressFreeBalance({ address: from, networkKey: originNetworkKey, token: originTokenInfo.slug });
 
           if (new BigN(balance).minus(value).lt(srcMinAmount)) {
             inputTransaction.warnings.push(new TransactionWarning(BasicTxWarningCode.NOT_ENOUGH_EXISTENTIAL_DEPOSIT, ''));


### PR DESCRIPTION
### Related issue(s)

- #1657

### Is your feature request related to a problem(s)? Please describe.

- Fix don't validate receiver balance

### Describe the solution you'd like

- Fix don't validate receiver balance

### Describe alternatives you've considered

- No

### Additional context

- No
