### PR TITLE
[Issue-1888] WebApp - Do not show confirmation after performing any transaction with extension account

### DIFF
--- a/packages/extension-koni-ui/src/components/Modal/ConfirmationModal.tsx
+++ b/packages/extension-koni-ui/src/components/Modal/ConfirmationModal.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BaseModal } from '@subwallet/extension-koni-ui/components/Modal/BaseModal';
+import { CONFIRMATION_MODAL_INDEX } from '@subwallet/extension-koni-ui/constants';
 import Confirmations from '@subwallet/extension-koni-ui/Popup/Confirmations';
 import { RootState } from '@subwallet/extension-koni-ui/stores';
 import { ThemeProps } from '@subwallet/extension-koni-ui/types';
@@ -26,6 +27,7 @@ function Component ({ className = '', id, onCancel }: Props): React.ReactElement
       onCancel={onCancel}
       transitionName={'fade'}
       wrapClassName={CN({ hidden: !hasConfirmations })}
+      zIndex={CONFIRMATION_MODAL_INDEX}
     >
       <Confirmations className={'confirmation-content-wrapper'} />
     </BaseModal>

--- a/packages/extension-koni-ui/src/constants/modal.ts
+++ b/packages/extension-koni-ui/src/constants/modal.ts
@@ -1,6 +1,9 @@
 // Copyright 2019-2022 @subwallet/extension-koni-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+export const DEFAULT_MODAL_INDEX = 1000;
+export const CONFIRMATION_MODAL_INDEX = DEFAULT_MODAL_INDEX + 100;
+
 export const SELECT_ACCOUNT_MODAL = 'account-list-modal';
 export const CREATE_ACCOUNT_MODAL = 'create-account-modal';
 export const CUSTOMIZE_MODAL = 'customize-modal';


### PR DESCRIPTION
### Related issue(s)

- #1888

### Is your feature request related to a problem(s)? Please describe.

- Fix not show confirmation popup in case create transaction with popup

### Describe the solution you'd like

- Fix not show confirmation popup in case create transaction with popup

### Describe alternatives you've considered

- No

### Additional context

- No
