### PR TITLE
[Issue-1910] Handle the case of auto lock after import multi account

### DIFF
--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -264,6 +264,7 @@ export interface RequestAccountEdit {
 
 export interface RequestAccountForget {
   address: string;
+  lockAfter: boolean;
 }
 
 export interface RequestAccountShow {

--- a/packages/extension-base/src/koni/background/handlers/Extension.ts
+++ b/packages/extension-base/src/koni/background/handlers/Extension.ts
@@ -1287,7 +1287,7 @@ export default class KoniExtension {
     return addressDict;
   }
 
-  private async accountsForgetOverride ({ address }: RequestAccountForget): Promise<boolean> {
+  private async accountsForgetOverride ({ address, lockAfter }: RequestAccountForget): Promise<boolean> {
     keyring.forgetAccount(address);
     await new Promise<void>((resolve) => {
       this.#koniState.removeAccountRef(address, () => {
@@ -1321,6 +1321,10 @@ export default class KoniExtension {
     });
 
     await this.#koniState.disableMantaPay(address);
+
+    if (lockAfter) {
+      this.checkLockAfterMigrate();
+    }
 
     return true;
   }
@@ -1458,9 +1462,9 @@ export default class KoniExtension {
           this._addAddressesToAuthList(addressList, isAllowed);
         });
 
-        if (this.#alwaysLock) {
-          this.keyringLock();
-        }
+        // if (this.#alwaysLock) {
+        //   this.keyringLock();
+        // }
       } catch (error) {
         throw new Error((error as Error).message);
       }
@@ -2927,9 +2931,26 @@ export default class KoniExtension {
 
   // Migrate password
 
+  private checkLockAfterMigrate () {
+    const pairs = keyring.getPairs();
+
+    const needMigrate = !!pairs
+      .filter((acc) => acc.address !== ALL_ACCOUNT_KEY && !acc.meta.isExternal && !acc.meta.isInjected)
+      .filter((acc) => !acc.meta.isMasterPassword)
+      .length;
+
+    if (!needMigrate) {
+      if (this.#alwaysLock) {
+        this.keyringLock();
+      }
+    }
+  }
+
   private keyringMigrateMasterPassword ({ address, password }: RequestMigratePassword): ResponseMigratePassword {
     try {
       keyring.migrateWithMasterPassword(address, password);
+
+      this.checkLockAfterMigrate();
     } catch (e) {
       console.error(e);
 

--- a/packages/extension-koni-ui/src/Popup/Keyring/ApplyMasterPassword/index.tsx
+++ b/packages/extension-koni-ui/src/Popup/Keyring/ApplyMasterPassword/index.tsx
@@ -229,7 +229,7 @@ const Component: React.FC<Props> = (props: Props) => {
         .then(() => {
           setDeleting(true);
           setTimeout(() => {
-            forgetAccount(currentAccount.address)
+            forgetAccount(currentAccount.address, true)
               .then(() => {
                 setIsError(false);
               })

--- a/packages/extension-koni-ui/src/Popup/Settings/Security/index.tsx
+++ b/packages/extension-koni-ui/src/Popup/Settings/Security/index.tsx
@@ -48,7 +48,7 @@ interface AutoLockOption {
 const editAutoLockTimeModalId = EDIT_AUTO_LOCK_TIME_MODAL;
 const editUnlockTypeModalId = EDIT_UNLOCK_TYPE_MODAL;
 
-const timeOptions = [5, 10, 15, 30, 60];
+const timeOptions = [0, 5, 10, 15, 30, 60];
 
 const Component: React.FC<Props> = (props: Props) => {
   const { className } = props;

--- a/packages/extension-koni-ui/src/messaging/accounts/edit.ts
+++ b/packages/extension-koni-ui/src/messaging/accounts/edit.ts
@@ -1,0 +1,12 @@
+// Copyright 2019-2022 @subwallet/extension-koni-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { sendMessage } from '../base';
+
+export async function editAccount (address: string, name: string): Promise<boolean> {
+  return sendMessage('pri(accounts.edit)', { address, name });
+}
+
+export async function forgetAccount (address: string, lockAfter = false): Promise<boolean> {
+  return sendMessage('pri(accounts.forget)', { address, lockAfter });
+}

--- a/packages/extension-koni-ui/src/messaging/accounts/index.ts
+++ b/packages/extension-koni-ui/src/messaging/accounts/index.ts
@@ -4,6 +4,7 @@
 export * from './addressBook';
 export * from './create';
 export * from './currentAccount';
+export * from './edit';
 export * from './export';
 export * from './inject';
 export * from './validate';

--- a/packages/extension-koni-ui/src/messaging/index.ts
+++ b/packages/extension-koni-ui/src/messaging/index.ts
@@ -13,10 +13,6 @@ import { _ChainState, _NetworkUpsertParams, _ValidateCustomAssetRequest, _Valida
 import { SWTransactionResponse, SWTransactionResult } from '@subwallet/extension-base/services/transaction-service/types';
 import { sendMessage } from '@subwallet/extension-koni-ui/messaging/base';
 
-export async function editAccount (address: string, name: string): Promise<boolean> {
-  return sendMessage('pri(accounts.edit)', { address, name });
-}
-
 export async function showAccount (address: string, isShowing: boolean): Promise<boolean> {
   return sendMessage('pri(accounts.show)', { address, isShowing });
 }
@@ -27,10 +23,6 @@ export async function tieAccount (address: string, genesisHash: string | null): 
 
 export async function validateAccount (address: string, password: string): Promise<boolean> {
   return sendMessage('pri(accounts.validate)', { address, password });
-}
-
-export async function forgetAccount (address: string): Promise<boolean> {
-  return sendMessage('pri(accounts.forget)', { address });
 }
 
 export async function approveAuthRequest (id: string): Promise<boolean> {


### PR DESCRIPTION
### Related issue(s)

- #1910

### Is your feature request related to a problem(s)? Please describe.

- Locks automatically only after migration is complete

### Describe the solution you'd like

- Locks automatically only after migration is complete

### Describe alternatives you've considered

- No

### Additional context

- No
