### PR TITLE
[Issue-2020] Hide the AutoSelect validator/collator/dApp button if this method is not supported

### DIFF
--- a/packages/extension-koni-ui/src/components/Field/PoolSelector.tsx
+++ b/packages/extension-koni-ui/src/components/Field/PoolSelector.tsx
@@ -137,6 +137,8 @@ const Component = (props: Props, ref: ForwardedRef<InputRef>) => {
       });
   }, [items, selectedFilters, sortSelection]);
 
+  const havePredefinedPool = useMemo(() => PREDEFINED_STAKING_POOL[chain] !== undefined, [chain]);
+
   const _onSelectItem = useCallback((value: string) => {
     onChange && onChange({ target: { value } });
   }, [onChange]);
@@ -298,18 +300,22 @@ const Component = (props: Props, ref: ForwardedRef<InputRef>) => {
               size='xs'
               type='ghost'
             />
-            <Button
-              disabled={isDisabled}
-              icon={(
-                <Icon
-                  phosphorIcon={Lightning}
-                  size='sm'
+            {
+              havePredefinedPool && (
+                <Button
+                  disabled={isDisabled}
+                  icon={(
+                    <Icon
+                      phosphorIcon={Lightning}
+                      size='sm'
+                    />
+                  )}
+                  onClick={onClickLightningBtn}
+                  size='xs'
+                  type='ghost'
                 />
-              )}
-              onClick={onClickLightningBtn}
-              size='xs'
-              type='ghost'
-            />
+              )
+            }
           </div>
         )}
         title={label || placeholder || t('Select pool')}

--- a/packages/extension-koni-ui/src/components/SelectValidatorInput.tsx
+++ b/packages/extension-koni-ui/src/components/SelectValidatorInput.tsx
@@ -7,7 +7,7 @@ import { ThemeProps } from '@subwallet/extension-koni-ui/types';
 import { toShort } from '@subwallet/extension-koni-ui/utils';
 import { ActivityIndicator, Button, Icon } from '@subwallet/react-ui';
 import CN from 'classnames';
-import { Book, Lightning } from 'phosphor-react';
+import { Book } from 'phosphor-react';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -91,26 +91,15 @@ const Component: React.FC<Props> = (props: Props) => {
                 />
               )
               : (
-                <>
-                  <Button
-                    disabled={disabled}
-                    icon={<Icon
-                      phosphorIcon={Book}
-                      size={'sm'}
-                    />}
-                    size={'xs'}
-                    type={'ghost'}
-                  />
-                  <Button
-                    disabled={disabled}
-                    icon={<Icon
-                      phosphorIcon={Lightning}
-                      size={'sm'}
-                    />}
-                    size={'xs'}
-                    type={'ghost'}
-                  />
-                </>
+                <Button
+                  disabled={disabled}
+                  icon={<Icon
+                    phosphorIcon={Book}
+                    size={'sm'}
+                  />}
+                  size={'xs'}
+                  type={'ghost'}
+                />
               )
           }
         </div>


### PR DESCRIPTION
### Related issue(s)

- #2020

### Is your feature request related to a problem(s)? Please describe.

- Hide the AutoSelect validator/collator/dApp button if this method is not supported

### Describe the solution you'd like

- Hide the AutoSelect validator/collator/dApp button if this method is not supported

### Describe alternatives you've considered

- No

### Additional context

- No
