### PR TITLE
[Issue-2146] Re-check bug undefined is not an object when perform transaction

### DIFF
--- a/packages/extension-base/src/services/setting-service/SettingService.ts
+++ b/packages/extension-base/src/services/setting-service/SettingService.ts
@@ -64,14 +64,14 @@ export default class SettingService {
   // Use for mobile only
   public get isAlwaysRequired (): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
-      this.settingsStore.get('Settings', (value) => {
+      this.getSettings((value) => {
         resolve(!value.timeAutoLock);
       });
     });
   }
 
   public resetWallet () {
-    this.settingsStore.set('Settings', DEFAULT_SETTING);
-    this.passPhishingStore.set('PassPhishing', {});
+    this.setSettings(DEFAULT_SETTING);
+    this.setPassPhishing({});
   }
 }


### PR DESCRIPTION
### Related issue(s)

- #2146

### Is your feature request related to a problem(s)? Please describe.

- Fix error when get setting

### Describe the solution you'd like

- Fix error when get setting

### Describe alternatives you've considered

- No

### Additional context

- No
