### PR TITLE
[Issue-2291] The default pool setting for Vara is SubWallet Official

### DIFF
--- a/packages/extension-base/src/constants/staking.ts
+++ b/packages/extension-base/src/constants/staking.ts
@@ -3,5 +3,6 @@
 
 export const PREDEFINED_STAKING_POOL: Record<string, number> = {
   kusama: 80,
-  polkadot: 39
+  polkadot: 39,
+  vara_network: 29
 };


### PR DESCRIPTION
### Related issue(s)

- #2291

### Is your feature request related to a problem(s)? Please describe.

- Add pool default for Vara

### Describe the solution you'd like

- Add pool default for Vara

### Describe alternatives you've considered

- No

### Additional context

- No
