### PR TITLE
[Issue 2211] Effect when open modal Select token, Select account in case Buy token 

### DIFF
--- a/packages/extension-koni-ui/src/components/Modal/BaseModal.tsx
+++ b/packages/extension-koni-ui/src/components/Modal/BaseModal.tsx
@@ -49,7 +49,7 @@ export const BaseModal = styled(Component)<Props>(({ theme: { token } }: Props) 
       bottom: token.paddingLG,
       top: token.paddingLG,
       maxWidth: 404,
-
+      animationDuration: '0.45s',
       '.ant-sw-modal-content': {
         width: '100%',
         height: '100%',

--- a/packages/extension-koni-ui/src/components/Modal/BaseSelectModal.tsx
+++ b/packages/extension-koni-ui/src/components/Modal/BaseSelectModal.tsx
@@ -26,7 +26,12 @@ function Component ({ children, className, fullSizeOnMobile = true, motion, ...p
           '-desktop': isWebUI,
           '-mobile': !isWebUI,
           '-full-size-on-mobile': fullSizeOnMobile
-        })}
+        },
+        _motion === 'move-right' && [
+          'ant-move-right-enter',
+          'ant-move-right-enter-active'
+        ]
+        )}
         motion={_motion}
         width={'100%'}
       >
@@ -49,6 +54,7 @@ export const BaseSelectModal = styled(Component)(({ theme: { token } }: ThemePro
       bottom: token.paddingLG,
       top: token.paddingLG,
       maxWidth: 404,
+      animationDuration: '0.45s',
 
       '.ant-sw-modal-content': {
         width: '100%',


### PR DESCRIPTION
![2015](https://github.com/Koniverse/SubWallet-Extension/assets/117999489/fc591cc8-9f45-48e2-909c-815bf4de712d)

Actual: Modal move to center then snap back to the right
Expect: Modal animation must show normally