### PR TITLE
[Issue 1958] WebApp - Navigate incorrect in case back to Import account

### DIFF
--- a/packages/extension-koni-ui/src/Popup/Account/ImportSeedPhrase.tsx
+++ b/packages/extension-koni-ui/src/Popup/Account/ImportSeedPhrase.tsx
@@ -3,7 +3,7 @@
 
 import { CloseIcon, Layout, PageWrapper, PhraseNumberSelector, SeedPhraseInput } from '@subwallet/extension-koni-ui/components';
 import InstructionContainer, { InstructionContentType } from '@subwallet/extension-koni-ui/components/InstructionContainer';
-import { DEFAULT_ACCOUNT_TYPES, IMPORT_ACCOUNT_MODAL, SELECTED_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants';
+import { DEFAULT_ACCOUNT_TYPES, IMPORT_ACCOUNT_MODAL, IMPORT_SEED_MODAL, SELECTED_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants';
 import { ScreenContext } from '@subwallet/extension-koni-ui/contexts/ScreenContext';
 import { useAutoNavigateToCreatePassword, useCompleteCreateAccount, useDefaultNavigate, useFocusFormItem, useGetDefaultAccountName, useGoBackFromCreateAccount, useNotification, useTranslation, useUnlockChecker } from '@subwallet/extension-koni-ui/hooks';
 import { createAccountSuriV2, validateSeedV2 } from '@subwallet/extension-koni-ui/messaging';
@@ -62,7 +62,7 @@ const Component: React.FC<Props> = ({ className }: Props) => {
   const notification = useNotification();
 
   const onComplete = useCompleteCreateAccount();
-  const onBack = useGoBackFromCreateAccount(IMPORT_ACCOUNT_MODAL);
+  const onBack = useGoBackFromCreateAccount(isWebUI ? IMPORT_ACCOUNT_MODAL : IMPORT_SEED_MODAL);
 
   const accountName = useGetDefaultAccountName();
 

--- a/packages/extension-koni-ui/src/Popup/Account/ImportSeedPhrase.tsx
+++ b/packages/extension-koni-ui/src/Popup/Account/ImportSeedPhrase.tsx
@@ -3,7 +3,7 @@
 
 import { CloseIcon, Layout, PageWrapper, PhraseNumberSelector, SeedPhraseInput } from '@subwallet/extension-koni-ui/components';
 import InstructionContainer, { InstructionContentType } from '@subwallet/extension-koni-ui/components/InstructionContainer';
-import { DEFAULT_ACCOUNT_TYPES, IMPORT_SEED_MODAL, SELECTED_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants';
+import { DEFAULT_ACCOUNT_TYPES, IMPORT_ACCOUNT_MODAL, SELECTED_ACCOUNT_TYPE } from '@subwallet/extension-koni-ui/constants';
 import { ScreenContext } from '@subwallet/extension-koni-ui/contexts/ScreenContext';
 import { useAutoNavigateToCreatePassword, useCompleteCreateAccount, useDefaultNavigate, useFocusFormItem, useGetDefaultAccountName, useGoBackFromCreateAccount, useNotification, useTranslation, useUnlockChecker } from '@subwallet/extension-koni-ui/hooks';
 import { createAccountSuriV2, validateSeedV2 } from '@subwallet/extension-koni-ui/messaging';
@@ -62,7 +62,7 @@ const Component: React.FC<Props> = ({ className }: Props) => {
   const notification = useNotification();
 
   const onComplete = useCompleteCreateAccount();
-  const onBack = useGoBackFromCreateAccount(IMPORT_SEED_MODAL);
+  const onBack = useGoBackFromCreateAccount(IMPORT_ACCOUNT_MODAL);
 
   const accountName = useGetDefaultAccountName();
 


### PR DESCRIPTION
Describe the bug
Version test: https://fcc535f4.subwallet-webapp.pages.dev/

To reproduce the bug
Steps:

Go to Import account -> Import from seed phrase
Click on Back button
Observe the displayed screen
Actual: Back to Select account type screen

![Image](https://github.com/Koniverse/SubWallet-Extension/assets/117999489/9d2c4ccd-592a-498e-a69a-2f625e05d5d3)


Expect: Back to Import account screen

