### PR TITLE
[Issue-2385] Add Azero Domains Pool & Validator as default option when users stake A0

### DIFF
--- a/packages/extension-base/src/constants/staking.ts
+++ b/packages/extension-base/src/constants/staking.ts
@@ -4,7 +4,8 @@
 export const PREDEFINED_STAKING_POOL: Record<string, number> = {
   kusama: 80,
   polkadot: 39,
-  vara_network: 29
+  vara_network: 29,
+  aleph: 55
 };
 
 export const MAX_NOMINATIONS = '16';


### PR DESCRIPTION
### Related issue(s)

- #2385

### Is your feature request related to a problem(s)? Please describe.

- Add default pool for Aleph Zero

### Describe the solution you'd like

- Add default pool for Aleph Zero

### Describe alternatives you've considered

- No

### Additional context

- No
