### PR TITLE
[Issue-2397] Show "select account" on the history screen in case disconnect injected account

### DIFF
--- a/packages/extension-koni-ui/src/hooks/history/useHistorySelection.tsx
+++ b/packages/extension-koni-ui/src/hooks/history/useHistorySelection.tsx
@@ -38,6 +38,14 @@ export default function useHistorySelection () {
     }
   }, [accounts, currentAccount?.address]);
 
+  useEffect(() => {
+    const isSelectedAccountExist = accounts.some((account) => account.address === selectedAddress);
+
+    if (!isSelectedAccountExist) {
+      setSelectedAddress((accounts.find((a) => !isAccountAll(a.address)))?.address || '');
+    }
+  }, [accounts, selectedAddress]);
+
   return {
     selectedAddress,
     setSelectedAddress,


### PR DESCRIPTION
Related issue: #2397