### PR TITLE
[Issue-2429] Do not display the account in the account details tab in case the entire account balance is locked

### DIFF
--- a/packages/extension-koni-ui/src/Popup/Home/Tokens/DetailModal.tsx
+++ b/packages/extension-koni-ui/src/Popup/Home/Tokens/DetailModal.tsx
@@ -137,16 +137,17 @@ function Component ({ className = '', currentTokenInfo, id, onCancel, tokenBalan
 
   const symbol = currentTokenInfo?.symbol || '';
 
+  const filteredItems = useMemo(() => {
+    return accountItems.filter((item) => {
+      return new BigN(item.free).plus(item.locked).gt(0);
+    });
+  }, [accountItems]);
+
   useEffect(() => {
     if (!isActive) {
       form?.resetFields();
     }
   }, [form, isActive]);
-
-  const filteredItems = accountItems
-    .filter((item) => {
-      return new BigN(item.free).gt(0);
-    });
 
   return (
     <SwModal


### PR DESCRIPTION
Related issue: #2429 