### PR TITLE
[Issue 2393] WebApp - Show $balance = NaN in the history screen when get price service is down

### DIFF
--- a/packages/extension-koni-ui/src/components/History/HistoryItem.tsx
+++ b/packages/extension-koni-ui/src/components/History/HistoryItem.tsx
@@ -178,7 +178,7 @@ function Component (
           decimalOpacity={0.45}
           hide={!isShowBalance}
           suffix={item?.amount?.symbol}
-          value={balanceValue}
+          value={balanceValue.isNaN() ? '0' : balanceValue}
         />
         <Number
           className={'__meta'}
@@ -188,7 +188,7 @@ function Component (
           intOpacity={0.45}
           prefix='$'
           unitOpacity={0.45}
-          value={convertedBalanceValue}
+          value={convertedBalanceValue.isNaN() ? '0' : convertedBalanceValue}
         />
       </div>
 


### PR DESCRIPTION
**Describe the bug**
Show $balance = NaN in the history screen when get price service is down

![image](https://github.com/Koniverse/SubWallet-Extension/assets/130966515/e8d8452c-d236-4f4b-a263-e8bcb8f479da)

Expect: Show $balance = 0