### PR TITLE
[Issue 2394] WebApp - Show incorrect account on the Token detail screen when disconnect account injected

### DIFF
--- a/packages/extension-koni-ui/src/Popup/Home/Tokens/DetailModal.tsx
+++ b/packages/extension-koni-ui/src/Popup/Home/Tokens/DetailModal.tsx
@@ -11,7 +11,7 @@ import { useSelector } from '@subwallet/extension-koni-ui/hooks';
 import useTranslation from '@subwallet/extension-koni-ui/hooks/common/useTranslation';
 import { ThemeProps } from '@subwallet/extension-koni-ui/types';
 import { TokenBalanceItemType } from '@subwallet/extension-koni-ui/types/balance';
-import { isAccountAll } from '@subwallet/extension-koni-ui/utils';
+import { findAccountByAddress, isAccountAll } from '@subwallet/extension-koni-ui/utils';
 import { Form, Icon, ModalContext, Number } from '@subwallet/react-ui';
 import BigN from 'bignumber.js';
 import CN from 'classnames';
@@ -58,7 +58,7 @@ function Component ({ className = '', currentTokenInfo, id, onCancel, tokenBalan
   const isActive = checkActive(id);
   const { isWebUI } = useContext(ScreenContext);
 
-  const { currentAccount, isAllAccount } = useSelector((state) => state.accountState);
+  const { accounts, currentAccount, isAllAccount } = useSelector((state) => state.accountState);
   const { balanceMap } = useSelector((state) => state.balance);
 
   const [form] = Form.useForm<FormState>();
@@ -116,7 +116,7 @@ function Component ({ className = '', currentTokenInfo, id, onCancel, tokenBalan
       if (isAllAccount) {
         return !isAccountAll(address);
       } else {
-        return isSameAddress(address, currentAccount?.address || '');
+        return isSameAddress(address, currentAccount?.address || '') && !!findAccountByAddress(accounts, address);
       }
     };
 
@@ -136,7 +136,7 @@ function Component ({ className = '', currentTokenInfo, id, onCancel, tokenBalan
 
       return bTotal.minus(aTotal).toNumber();
     });
-  }, [balanceMap, currentAccount?.address, currentTokenInfo?.slug, isAllAccount]);
+  }, [accounts, balanceMap, currentAccount?.address, currentTokenInfo?.slug, isAllAccount]);
 
   const symbol = currentTokenInfo?.symbol || '';
 

--- a/packages/extension-koni-ui/src/components/TokenItem/AccountTokenBalanceItem.tsx
+++ b/packages/extension-koni-ui/src/components/TokenItem/AccountTokenBalanceItem.tsx
@@ -38,6 +38,10 @@ const Component: React.FC<Props> = (props: Props) => {
     return account?.name;
   }, [account?.name]);
 
+  if (!account) {
+    return (<></>);
+  }
+
   const decimals = tokenInfo?.decimals || 0;
   const symbol = tokenInfo?.symbol || '';
 


### PR DESCRIPTION
**Describe the bug**
Show incorrect account on the Token detail screen when disconnect account injected

**To Reproduce**
Steps to reproduce the behavior:
1. Open the WebApp
2. Perform connecting extension successfully
3. Switch to All accounts mode
4. Go to the token details screen of any token (Substrate token)
5. Observe the list token displayed
6. Disconnected any Substrate account on Extension
7. Back to token details screen on WebApp then observe the list token displayed again

**Actual:** Still shows account disconnected
- Only show address, not show account name
![image](https://github.com/Koniverse/SubWallet-Extension/assets/130966515/b69c15cc-406e-4cd0-8b1f-f1064fcb30e3)

**Expect:** Do not show disconnected account