### PR TITLE
[Issue-2616] Fix show incorrect token in case the wallet has only 1 account type

### DIFF
--- a/packages/extension-base/src/services/balance-service/helpers/subscribe/balance.ts
+++ b/packages/extension-base/src/services/balance-service/helpers/subscribe/balance.ts
@@ -48,7 +48,7 @@ const filterAddress = (addresses: string[], chainInfo: _ChainInfo): [string[], s
   const [substrateAddresses, evmAddresses] = categoryAddresses(addresses);
 
   if (isEvmChain) {
-    return [evmAddresses, []];
+    return [evmAddresses, substrateAddresses];
   } else {
     const fetchList: string[] = [];
     const unfetchList: string[] = [];


### PR DESCRIPTION
Related issue: #2616 