### PR TITLE
[Issue 2608] WebApp - Unable to scroll list account when connect a Ledger device

### DIFF
--- a/packages/extension-web-ui/src/Popup/Account/ConnectLedger.tsx
+++ b/packages/extension-web-ui/src/Popup/Account/ConnectLedger.tsx
@@ -436,6 +436,10 @@ const ConnectLedger = styled(Component)<Props>(({ theme: { token } }: Props) => 
       }
     },
 
+    '.ant-sw-list.-display-row': {
+      paddingBottom: token.padding
+    },
+
     '.loading': {
       '.anticon': {
         animation: 'spinner-loading 1s infinite linear'


### PR DESCRIPTION
**Describe the bug**

- [x] Unable to scroll list account when connect a Ledger device

**To reproduce the bug**
Step:
1. Perform connect a Ledger device
2. On list account, perform scroll and observe the displayed screen

Actual: Unable to scroll list account

![Image](https://github.com/Koniverse/SubWallet-Extension/assets/117999489/cc64a06e-3e2f-4fcf-8604-576e3bd903ce)

Reason: Zoom in/Zoom out browser