### PR TITLE
[WebApp] [Issue-3305] Move step shorten metadata and calculate metadataHash to client

### DIFF
--- a/packages/extension-base/src/utils/metadata.ts
+++ b/packages/extension-base/src/utils/metadata.ts
@@ -42,7 +42,7 @@ export const cacheMetadata = (
       return;
     }
 
-    const systemChain = await api.rpc.system.chain();
+    const systemChain = api.runtimeChain;
     // const _metadata: Option<OpaqueMetadata> = await api.call.metadata.metadataAtVersion(15);
     // const metadataHex = _metadata.isSome ? _metadata.unwrap().toHex().slice(2) : ''; // Need unwrap to create metadata object
     let hexV15: HexString | undefined;

--- a/packages/extension-base/src/utils/metadata.ts
+++ b/packages/extension-base/src/utils/metadata.ts
@@ -47,10 +47,18 @@ export const cacheMetadata = (
     // const metadataHex = _metadata.isSome ? _metadata.unwrap().toHex().slice(2) : ''; // Need unwrap to create metadata object
     let hexV15: HexString | undefined;
 
-    const metadataV15 = await api.call.metadata.metadataAtVersion(15);
+    const metadataHex = api.runtimeMetadata.toHex();
 
-    if (!metadataV15.isEmpty) {
-      hexV15 = metadataV15.unwrap().toHex();
+    if (api.call.metadata.metadataAtVersion) {
+      const metadataV15 = await api.call.metadata.metadataAtVersion(15);
+
+      if (!metadataV15.isEmpty) {
+        hexV15 = metadataV15.unwrap().toHex();
+      }
+    } else {
+      if (api.runtimeMetadata.version === 15) {
+        hexV15 = metadataHex;
+      }
     }
 
     chainService?.upsertMetadata(chain, {
@@ -58,7 +66,7 @@ export const cacheMetadata = (
       genesisHash: genesisHash,
       specName: specName,
       specVersion: currentSpecVersion,
-      hexValue: api.runtimeMetadata.toHex(),
+      hexValue: metadataHex,
       types: getSpecTypes(api.registry, systemChain, api.runtimeVersion.specName, api.runtimeVersion.specVersion) as unknown as Record<string, string>,
       userExtensions: getSpecExtensions(api.registry, systemChain, api.runtimeVersion.specName),
       hexV15


### PR DESCRIPTION
### Related issue(s)

- #3305

### Is your feature request related to a problem(s)? Please describe.

- Adding `hexV15` for metadata
- Using `@polkadot-api/merkleize-metadata` to handle metadata instead of using API

### Describe the solution you'd like

- Adding `hexV15` for metadata
- Using `@polkadot-api/merkleize-metadata` to handle metadata instead of using API

### Describe alternatives you've considered

- No

### Additional context

- No
