### PR TITLE
[Issue-3752] Extension - Update address for TON testnet in the token detail screen on All accounts mode

### DIFF
--- a/packages/extension-koni-ui/src/components/TokenItem/AccountTokenBalanceItem.tsx
+++ b/packages/extension-koni-ui/src/components/TokenItem/AccountTokenBalanceItem.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { _ChainAsset } from '@subwallet/chain-list/types';
+import { _isChainTonCompatible } from '@subwallet/extension-base/services/chain-service/utils';
 import { getExplorerLink } from '@subwallet/extension-base/services/transaction-service/utils';
 import { BalanceItem } from '@subwallet/extension-base/types';
 import { Avatar } from '@subwallet/extension-koni-ui/components';
@@ -46,7 +47,13 @@ const Component: React.FC<Props> = (props: Props) => {
   const total = useMemo(() => new BigN(free).plus(locked).toString(), [free, locked]);
   const addressPrefix = useGetChainPrefixBySlug(tokenInfo?.originChain);
 
-  const reformatedAddress = useMemo(() => reformatAddress(address, addressPrefix), [address, addressPrefix]);
+  const reformatedAddress = useMemo(() => {
+    if (chainInfo && _isChainTonCompatible(chainInfo)) {
+      return reformatAddress(address, chainInfo.isTestnet ? 0 : 1);
+    }
+
+    return reformatAddress(address, addressPrefix);
+  }, [address, addressPrefix, chainInfo]);
 
   const name = useMemo(() => {
     return account?.name;


### PR DESCRIPTION
### Related issue(s)

- #3752

### Is your feature request related to a problem(s)? Please describe.

- Update logic show address on balance detail modal

### Describe the solution you'd like

- Update logic show address on balance detail modal

### Describe alternatives you've considered

- No

### Additional context

- No
