### PR TITLE
[Issue-3772] Still show All accounts in case wallet has only 1 account after removing account

### DIFF
--- a/packages/extension-base/src/services/keyring-service/context/handlers/Modify.ts
+++ b/packages/extension-base/src/services/keyring-service/context/handlers/Modify.ts
@@ -155,7 +155,7 @@ export class AccountModifyHandler extends AccountBaseHandler {
     if (afterDeleteAccounts.length > 1) {
       this.state.saveCurrentAccountProxyId(ALL_ACCOUNT_KEY);
     } else {
-      this.state.saveCurrentAccountProxyId(Object.keys(this.state.accounts)[0]);
+      this.state.saveCurrentAccountProxyId(afterDeleteAccounts[0]);
     }
 
     return addresses;


### PR DESCRIPTION
### Related issue(s)

- #3772

### Is your feature request related to a problem(s)? Please describe.

- Fix wrong current account after remove account

### Describe the solution you'd like

- Fix wrong current account after remove account

### Describe alternatives you've considered

- No

### Additional context

- No
