### PR TITLE
[Issue-3870] WalletConnect - Allow Polkadot namespace use EVM address

### DIFF
--- a/packages/extension-base/src/koni/background/handlers/Extension.ts
+++ b/packages/extension-base/src/koni/background/handlers/Extension.ts
@@ -42,7 +42,6 @@ import { EXTENSION_REQUEST_URL } from '@subwallet/extension-base/services/reques
 import { AuthUrls } from '@subwallet/extension-base/services/request-service/types';
 import { DEFAULT_AUTO_LOCK_TIME } from '@subwallet/extension-base/services/setting-service/constants';
 import { SWTransaction, SWTransactionResponse, SWTransactionResult, TransactionEmitter, ValidateTransactionResponseInput } from '@subwallet/extension-base/services/transaction-service/types';
-import { WALLET_CONNECT_EIP155_NAMESPACE } from '@subwallet/extension-base/services/wallet-connect-service/constants';
 import { isProposalExpired, isSupportWalletConnectChain, isSupportWalletConnectNamespace } from '@subwallet/extension-base/services/wallet-connect-service/helpers';
 import { ResultApproveWalletConnectSession, WalletConnectNotSupportRequest, WalletConnectSessionRequest } from '@subwallet/extension-base/services/wallet-connect-service/types';
 import { SWStorage } from '@subwallet/extension-base/storage';
@@ -2945,13 +2944,13 @@ export default class KoniExtension {
     Object.entries(availableNamespaces)
       .forEach(([key, namespace]) => {
         if (namespace.chains) {
-          const accounts: string[] = [];
+          const accounts: string[] = selectedAccounts.filter((address) => {
+            const [_namespace] = address.split(':');
+
+            return _namespace === key;
+          });
 
           const chains = uniqueStringArray(namespace.chains);
-
-          chains.forEach((chain) => {
-            accounts.push(...(selectedAccounts.filter((address) => isEthereumAddress(address) === (key === WALLET_CONNECT_EIP155_NAMESPACE)).map((address) => `${chain}:${address}`)));
-          });
 
           namespaces[key] = {
             accounts,

--- a/packages/extension-koni-ui/src/components/WalletConnect/Account/WCAccountSelect.tsx
+++ b/packages/extension-koni-ui/src/components/WalletConnect/Account/WCAccountSelect.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ALL_ACCOUNT_KEY } from '@subwallet/extension-base/constants';
-import { AccountJson } from '@subwallet/extension-base/types';
+import { AccountChainType, AccountJson } from '@subwallet/extension-base/types';
 import { isSameAddress } from '@subwallet/extension-base/utils';
 import { AccountItemWithProxyAvatar, AccountProxySelectorAllItem, AlertBox } from '@subwallet/extension-koni-ui/components';
 import { useTranslation } from '@subwallet/extension-koni-ui/hooks';
@@ -24,6 +24,7 @@ interface Props extends ThemeProps {
   selectedAccounts: string[];
   appliedAccounts: string[];
   availableAccounts: AccountJson[];
+  accountType: AccountChainType;
   onSelectAccount: (account: string, applyImmediately?: boolean) => VoidFunction;
   useModal: boolean;
   onApply: () => void;
@@ -33,7 +34,7 @@ interface Props extends ThemeProps {
 const renderEmpty = () => <GeneralEmptyList />;
 
 const Component: React.FC<Props> = (props: Props) => {
-  const { appliedAccounts, availableAccounts, className, id, namespace, onApply, onCancel, onSelectAccount, selectedAccounts, useModal } = props;
+  const { accountType, appliedAccounts, availableAccounts, className, id, onApply, onCancel, onSelectAccount, selectedAccounts, useModal } = props;
 
   const { t } = useTranslation();
 
@@ -44,26 +45,26 @@ const Component: React.FC<Props> = (props: Props) => {
   const isActive = checkActive(id);
 
   const noAccountTitle = useMemo(() => {
-    switch (namespace) {
-      case 'polkadot':
+    switch (accountType) {
+      case AccountChainType.SUBSTRATE:
         return t('No available Substrate account');
-      case 'eip155':
+      case AccountChainType.ETHEREUM:
         return t('No available EVM account');
       default:
         return t('No available account');
     }
-  }, [namespace, t]);
+  }, [accountType, t]);
 
   const noAccountDescription = useMemo(() => {
-    switch (namespace) {
-      case 'polkadot':
+    switch (accountType) {
+      case AccountChainType.SUBSTRATE:
         return t("You don't have any Substrate account to connect. Please create one or skip this step by hitting Cancel.");
-      case 'eip155':
+      case AccountChainType.ETHEREUM:
         return t("You don't have any EVM account to connect. Please create one or skip this step by hitting Cancel.");
       default:
         return t("You don't have any account to connect. Please create one or skip this step by hitting Cancel.");
     }
-  }, [namespace, t]);
+  }, [accountType, t]);
 
   const basicProxyAccounts = useMemo(() => {
     return availableAccounts.map(({ name, proxyId }) => ({ name, id: proxyId || '' }));

--- a/packages/extension-koni-ui/src/components/WalletConnect/Network/WCNetworkSelected.tsx
+++ b/packages/extension-koni-ui/src/components/WalletConnect/Network/WCNetworkSelected.tsx
@@ -32,7 +32,8 @@ const Component: React.FC<Props> = (props: Props) => {
             slug: '',
             name: t('{{number}} unknown network', { replace: { number: unSupportNetworks.length } })
           },
-          slug: ''
+          slug: '',
+          wcChain: ''
         }
       )
       : null;

--- a/packages/extension-koni-ui/src/types/walletConnect.ts
+++ b/packages/extension-koni-ui/src/types/walletConnect.ts
@@ -1,10 +1,13 @@
 // Copyright 2019-2022 @subwallet/extension-koni-ui authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { AccountChainType } from '@subwallet/extension-base/types';
 import { ChainInfo } from '@subwallet/extension-koni-ui/types/chain';
 
 export interface WalletConnectChainInfo {
   chainInfo: ChainInfo | null;
   slug: string;
   supported: boolean;
+  accountType?: AccountChainType;
+  wcChain: string;
 }

--- a/packages/extension-koni-ui/src/utils/walletConnect/index.ts
+++ b/packages/extension-koni-ui/src/utils/walletConnect/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { _ChainInfo } from '@subwallet/chain-list/types';
-import { findChainInfoByChainId, findChainInfoByHalfGenesisHash } from '@subwallet/extension-base/services/chain-service/utils';
+import { _chainInfoToChainType, findChainInfoByChainId, findChainInfoByHalfGenesisHash } from '@subwallet/extension-base/services/chain-service/utils';
 import { WALLET_CONNECT_EIP155_NAMESPACE, WALLET_CONNECT_POLKADOT_NAMESPACE } from '@subwallet/extension-base/services/wallet-connect-service/constants';
 import { AccountProxy } from '@subwallet/extension-base/types';
 import { WalletConnectChainInfo } from '@subwallet/extension-koni-ui/types';
@@ -18,7 +18,9 @@ export const chainsToWalletConnectChainInfos = (chainMap: Record<string, _ChainI
       return {
         chainInfo,
         slug: chainInfo?.slug || chain,
-        supported: !!chainInfo
+        supported: !!chainInfo,
+        accountType: chainInfo ? _chainInfoToChainType(chainInfo) : undefined,
+        wcChain: chain
       };
     } else if (namespace === WALLET_CONNECT_POLKADOT_NAMESPACE) {
       const chainInfo = findChainInfoByHalfGenesisHash(chainMap, info);
@@ -26,13 +28,16 @@ export const chainsToWalletConnectChainInfos = (chainMap: Record<string, _ChainI
       return {
         chainInfo,
         slug: chainInfo?.slug || chain,
-        supported: !!chainInfo
+        supported: !!chainInfo,
+        accountType: chainInfo ? _chainInfoToChainType(chainInfo) : undefined,
+        wcChain: chain
       };
     } else {
       return {
         chainInfo: null,
         slug: chain,
-        supported: false
+        supported: false,
+        wcChain: chain
       };
     }
   });


### PR DESCRIPTION
### Related issue(s)

- #3870

### Is your feature request related to a problem(s)? Please describe.

- [WC] Allow substrate network use evm address to connect

### Describe the solution you'd like

- [WC] Allow substrate network use evm address to connect

### Describe alternatives you've considered

- No

### Additional context

- No
