### PR TITLE
feat: Add 'Disable all networks' switch to Manage Networks page

### DIFF
--- a/packages/extension-base/src/koni/background/handlers/Extension.ts
+++ b/packages/extension-base/src/koni/background/handlers/Extension.ts
@@ -5721,6 +5721,8 @@ export default class KoniExtension {
         return await this.reconnectChain(request as string);
       case 'pri(chainService.disableChain)':
         return await this.disableChain(request as string);
+      case 'pri(chainService.disableAllChains)':
+        return this.#koniState.disableAllChains();
       case 'pri(chainService.removeChain)':
         return this.removeCustomChain(request as string);
       case 'pri(chainService.validateCustomChain)':

--- a/packages/extension-base/src/koni/background/handlers/State.ts
+++ b/packages/extension-base/src/koni/background/handlers/State.ts
@@ -949,6 +949,10 @@ export default class KoniState {
     return this.chainService.disableChain(chainSlug);
   }
 
+  public disableAllChains (): boolean {
+    return this.chainService.disableAllChains();
+  }
+
   public async enableChain (chainSlug: string, enableTokens = true): Promise<boolean> {
     if (enableTokens) {
       await this.chainService.updateAssetSettingByChain(chainSlug, true);

--- a/packages/extension-base/src/services/chain-service/index.ts
+++ b/packages/extension-base/src/services/chain-service/index.ts
@@ -1213,6 +1213,17 @@ export class ChainService {
     return true;
   }
 
+  public disableAllChains (): boolean {
+    const chainStateMap = this.getChainStateMap();
+    const activeChainSlugs = Object.keys(chainStateMap).filter((slug) => chainStateMap[slug].active);
+
+    for (const chainSlug of activeChainSlugs) {
+      this.disableChain(chainSlug);
+    }
+
+    return true;
+  }
+
   private checkExistedPredefinedChain (latestChainInfoMap: Record<string, _ChainInfo>, genesisHash?: string, evmChainId?: number) {
     let duplicatedSlug = '';
 


### PR DESCRIPTION
## Summary
Adds a "Disable all networks" switch to the Manage Networks settings page, allowing users to quickly disable all active networks with a single toggle.

## Changes
- **ChainService**: Added `disableAllChains()` method that iterates through all active chains and disables them
- **State Handler**: Added wrapper method for the chain service
- **Extension Handler**: Added message handler case for `'pri(chainService.disableAllChains)'`
- **ManageChains UI**: Added Switch component positioned between search bar and network list

## Testing
1. Navigate to Settings → Manage Networks
2. Toggle the "Disable all networks" switch
3. Verify all networks become disabled
4. Verify individual networks can be re-enabled from the list