### PR TITLE
qc: add koni-qc skill and EPIC-42 QA coverage tracking

### DIFF
--- a/.claude/skills/koni-qc/SKILL.md
+++ b/.claude/skills/koni-qc/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: koni-qc
+description: >
+  Use when building test docs or running quality control — writing test cases, a
+  test plan, a coverage matrix, traceability; edge cases, every AC needing
+  positive/negative/boundary tests; security / performance /
+  accessibility (NFR) testing; QA-ing a release, "is testing thorough / the suite
+  too thin?"; where test files/reports go (docs/tests layout, per-US); the unit-test/coverage bar (a test misclassified, env-pending, or broken
+  in the unit gate); automating
+  the test loop (generate tests from specs, run → report → sync, CI gate, broken
+  Covered-by handles, a reporter dropping cases); standing up the
+  integration/e2e live-stack harness (RLS as a real user, seed e2e users); QC-ing
+  a whole repo (QA epic, "is our testing done?"); making a run report
+  decision-grade ("is our 100% honest?"); a bug escaped or a
+  hotfix landed (bugs → regression tests, sweep CHANGELOG/git log for missed
+  cases); verifying UI against DESIGN.md + the
+  shadcn standard; or grading a skill ("score this SKILL.md") — even without naming koni-qc.
+---
+# koni-qc — QC methodology & coverage intelligence
+
+> koni-qc is the **intelligence to derive exhaustive, traceable coverage from
+> requirements** — the one thing koni-docs (templates), gstack (execution), and
+> koni-harness (gate) don't provide. It *fills* those templates and *drives* that
+> engine; it never reproduces them (the ownership split is §1).
+
+---
+
+## 1. What this owns vs. delegates
+
+| Concern | Owner |
+|---|---|
+| Test-design techniques, edge taxonomy, AC↔TC matrix, NFR/security, risk priority, the quality rubric | **koni-qc** (this) |
+| Test-doc templates / structure / `docs/tests/` layout | **koni-docs** — `references/templates/test-cases.md`, `test-report.md` (invoke; fill, don't redefine) |
+| Execution (browser / systematic QA, bug reports) | **gstack** — `qa` / `qa-only` / `investigate` / `browse` (invoke) |
+| UI verification against the repo's design | **gstack** `/design-review` — for any UI-bearing case, check it tracks the repo's `DESIGN.md` **and the shadcn standard** (both mandatory; criteria in `references/nfr.md` §UI) (invoke) |
+| Commit/release gate, loop, epic selection | **koni-harness** — `gate-runner.sh`, `loop.sh`, `sprint.sh` (invoke) |
+| Plan artifacts (brief → PRD → story) | **BMAD** (invoke) |
+| Repo scaffold incl. the `docs/tests/` tree at setup | **koni-setup** (invoke) — koni-qc self-scaffolds the tree only when koni-setup isn't used (see [`test-organization.md`](references/test-organization.md)) |
+| Skill-QC eval engines (when grading a *skill*) | **skill-creator** (triggering eval) · **writing-skills** (pressure-tests + best-practices rubric) · **`superpowers:code-reviewer`** (author-blind content) — invoked by [`skill-grading.md`](references/skill-grading.md) |
+
+koni-qc is the **Review / QA stage** of the koni-harness loop, made rigorous. It
+never re-implements the right-column owners.
+
+---
+
+## 2. Modes
+
+> **`EPIC-N` is the container; the user story is the coverage unit.** Specs group
+> per epic **directory** (`test-cases/EPIC-N/` — `index.md` + `US-x.y.md` per story)
+> but coverage, traceability, and planning are measured **per US** (each TC
+> `maps_to.us`) — see [`test-organization.md`](references/test-organization.md) §0–§1.
+
+| Mode | What it does | Uses |
+|---|---|---|
+| **Author test-cases for EPIC-N** | Read the epic's koni-docs inputs (PRD/stories/AC/ARCH) → produce a complete `docs/tests/test-cases/EPIC-N/` (index.md frame + per-US row files) with the canonical rich-TC table + the AC↔TC coverage matrix + edge + NFR/security cases, risk-ordered; a mixed API+UI surface splits into **layered suites** (API by-endpoint + functional) with the orthogonal coverage matrices | `test-design.md` · `edge-coverage.md` · `nfr.md` · `traceability.md` · `layered-suites.md` + koni-docs template |
+| **Run QC execution for EPIC-N** | Drive gstack per test case (for UI cases, run `/design-review` against the repo's `DESIGN.md` **+ the shadcn standard** — both mandatory); record results into koni-docs `test-report.md` run files with execution instrumentation (coverage % by AC/type, pass/fail, perf vs SLA) | `qc-workflow.md` §Execute + `report-quality.md` (the report content bar) + gstack (`qa`/`/design-review`) + koni-docs |
+| **Release gate for vX.Y.Z** | Check entry/exit criteria; produce the koni-docs release report + ship decision; run the koni-harness gate | `qc-workflow.md` §Release + `quality-bar.md` + koni-harness |
+| **Grade a skill (skill-QC)** | QC a *skill artifact* (not a product feature): score it /100 across 4 independent dimensions — triggering, rule-robustness, content, best-practices — to the **≥95 catalog standard** (re-grade the whole skill after any change, not just the diff) | `skill-grading.md` + skill-creator · writing-skills · `superpowers:code-reviewer` |
+| **Set up / standardize test docs** | Apply the standard `docs/tests/` taxonomy + by-epic test-code layout + the 3-place sync rule; if the repo wasn't bootstrapped by koni-setup, self-scaffold the missing tree | `test-organization.md` (+ koni-setup scaffolds at setup; koni-docs owns the templates) |
+| **Set the unit-coverage standard** | Own the per-function unit-test rule + coverage bar (the layer *below* the AC↔TC matrix); Dev authors the tests, koni-harness Self-verify enforces the bar | `unit-coverage.md` (+ koni-harness Execute/Self-verify; the repo's runner executes) |
+| **Automate the test loop** | Turn authored specs into a running, self-reporting, CI-gated suite: generate TC-ID-named tests → run → reporter writes `report.md` → sync Status/coverage% to the story → CI gate. Closes the "specs written, `— (manual)`, no reports" stall | `test-automation.md` (+ the repo's runner + `.github/workflows`; koni-harness gate) |
+| **Run the learning loop** | Operate koni-qc as a standing harness: turn every escaped bug into a REG test + a class finding + a generalization sweep; run the CHANGELOG + git-log change sweep so shipped changes never outrun the suite | `regression-learning.md` (+ `test-design.md` step 9 · `test-automation.md` signals · findings.md/bug-bash) |
+| **QC a whole project** | Stand up QC across an existing repo (not one epic): create the **QA-tracking epic** (a coverage story per app epic + infra/process stories + the QA ownership model), author the strategy, enforce artifact locations, require ≥1 execution, and gate on a whole-project **Definition-of-Done** + a **depth bar** (never ship thin stubs) | `whole-project-qc.md` (+ koni-docs stories · koni-setup scaffold · gstack execution · koni-harness gate) |
+
+---
+
+## 3. Activation — intent → reference
+
+| User intent | Load |
+|---|---|
+| "how do I turn this AC into test cases?" | `references/test-design.md` |
+| "structure the suite" / "API test cases" / "functional/UI test cases" / "status-code / error-code coverage" / "test-data registry / fixtures **in the suite doc**" / "bug-fix retest rounds" | `references/layered-suites.md` |
+| "what goes in the test report?" / "make the report decision-grade" / "report quality" / "skipped/blocked reasons" / "is our 100% honest?" (report content) | `references/report-quality.md` |
+| "stand up the integration/e2e harness" / "test RLS as a real user" / "e2e can't log in" / "the local stack won't boot for tests" | `references/live-harness.md` |
+| "a bug escaped / got hotfixed — now what?" / "turn this bug into tests" / "bug bash → tests" / "make the suite learn" / "what shipped since the last QC round?" / "sweep the changelog for missed cases" | `references/regression-learning.md` |
+| "am I missing edge cases?" / "make coverage thorough" | `references/edge-coverage.md` |
+| "trace AC to tests" / "TC IDs" / "coverage matrix" / "mark a TC deploy-only / ops-deploy" / "mark a TC verified-by-design-review / record the verification method" | `references/traceability.md` |
+| "security / performance / accessibility / i18n testing" | `references/nfr.md` |
+| "unit tests" / "test each function" / "unit coverage" / "TDD per function" / "why is my integration test failing/broken in the unit gate?" (lane scoping: `test-automation.md` §2) | `references/unit-coverage.md` |
+| "automate the tests" / "generate tests from the spec" / "run + report + sync coverage" / "self-updating / CI-gated suite" / "set up CI for tests" / "test-reports empty, nothing runs" / "the reporter is dropping cases" / "broken Covered-by handles / coverage honesty" (pipeline/handle integrity) | `references/test-automation.md` |
+| "set up QC for this project" / "audit our test coverage" / "stand up QA tracking" / "QA epic" / "is our testing done?" / "specs written but is QC complete?" / "QC the whole repo" (**across the whole repo, not one epic** — a single epic/release is the qc-workflow row above) | `references/whole-project-qc.md` |
+| "does the UI match the design?" / "check against DESIGN.md" / "shadcn conformance" | `references/nfr.md` §UI / visual conformance (DESIGN.md + shadcn) → gstack `/design-review` |
+| "run the whole QC process for **an epic / release**" (a whole *repo* → `whole-project-qc.md`) | `references/qc-workflow.md` |
+| "is this test doc good enough?" / "grade it" | `references/quality-bar.md` |
+| "grade this skill" / "score this SKILL.md" / "is this skill good enough?" / "QC a skill" | `references/skill-grading.md` |
+| "where do test files/reports go?" / "test-reports folder layout (date-first vs epic-first)" / "set up test folders" / "test directory structure" / "test organization" | `references/test-organization.md` |
+| "show me a worked example" | `references/customize-network-test-cases.example.md` |
+
+---
+
+## 4. The quality bar
+
+koni-qc's promise is **test docs better than both** the weak hand-made Koniverse
+suites *and* the best deliberately-authored ones. A suite is graded in three
+bands (A beat the manual baseline · B match the production standard · C close
+even its residual gaps) and passes only when it clears all of Band A and
+demonstrably exceeds B and C. The bands, their items, and the pass rule live in
+[`references/quality-bar.md`](references/quality-bar.md) — self-grade against it
+before review; do not restate the bands here.
+
+---
+
+## 5. Reference index
+
+| File | When to load |
+|---|---|
+| [`references/qc-workflow.md`](references/qc-workflow.md) | Running the QC lifecycle end-to-end (frame → design → review → execute → release gate); how it composes koni-docs / gstack / koni-harness |
+| [`references/test-design.md`](references/test-design.md) | Deriving positive/negative/boundary cases from an AC (partitioning, BVA, decision tables, state-transition, pairwise, error-guessing) |
+| [`references/layered-suites.md`](references/layered-suites.md) | Structuring the suite **by layer** to the exemplar bar — API by-endpoint tables (headers/payload/DB-changes/response-time), functional category-prefixed cases + UI-component rollups, the orthogonal coverage matrices (endpoint/status-code/error-code · pages/components/a11y), the named test-data registry, Open Questions, bug-fix retest rounds |
+| [`references/report-quality.md`](references/report-quality.md) | The execution-report **content bar** — honest actuals + denominator honesty, skipped/blocked with reason+action, failed-by-category root cause, perf stats, density telemetry, evidence links. Load when producing or grading a run report |
+| [`references/live-harness.md`](references/live-harness.md) | Standing up the **live-stack harness** — 2-credential RLS-as-user testing, per-test tenant isolation, self-seeding e2e, boot resilience, prod-safety rules. Load when integration/e2e needs a real stack that doesn't exist yet |
+| [`references/edge-coverage.md`](references/edge-coverage.md) | The edge-case taxonomy applied to every feature so coverage stops at thorough, not happy-path |
+| [`references/traceability.md`](references/traceability.md) | The TC-ID scheme, the canonical rich-TC table, and the **mandatory AC↔TC coverage matrix** + risk/regression tagging |
+| [`references/unit-coverage.md`](references/unit-coverage.md) | The **per-function unit-test** layer below the AC↔TC matrix — the per-function rule, the TDD cycle, and the unit-coverage bar (koni-qc owns the bar · Dev authors · harness Self-verify enforces) |
+| [`references/test-automation.md`](references/test-automation.md) | Load the moment specs are authored but `test-reports/` is empty — the generate → report → sync → CI spine (frozen parse contract + the **broken-handle enforcer** + the runner/CI bootstrap; reference reporter shipped at [`scripts/qc-report.mjs`](scripts/qc-report.mjs) with its contract self-test) |
+| [`references/regression-learning.md`](references/regression-learning.md) | The **QC harness loop** — every escaped bug becomes a REG test + a class finding + a generalization sweep; the mandatory CHANGELOG/git-log change sweep + change-coverage ledger; the miss post-mortem. Load on any real bug, hotfix, bug-bash, or round start |
+| [`references/whole-project-qc.md`](references/whole-project-qc.md) | Load when **standing up or auditing QC for a whole repo** (not one epic) — the layer above `qc-workflow.md`; the Modes row lists what it does |
+| [`references/nfr.md`](references/nfr.md) | Non-functional coverage — security (lead), performance/SLA, accessibility, i18n, reliability, compatibility, observability |
+| [`references/quality-bar.md`](references/quality-bar.md) | Grading a test doc against the three-band "better than both" rubric |
+| [`references/skill-grading.md`](references/skill-grading.md) | Grading a **skill artifact** /100 across 4 dimensions (triggering · rule-robustness · content · best-practices); the harness Review stage uses it when building a skill |
+| [`references/test-organization.md`](references/test-organization.md) | The standard `docs/tests/` taxonomy + by-epic/suffix test-code layout + the 3-place sync rule + status legend + scaffolding (koni-setup at setup, koni-qc self-scaffold fallback) |
+| [`references/customize-network-test-cases.example.md`](references/customize-network-test-cases.example.md) | A worked pilot showing the standard + the uplift over a manual suite |
+
+**Boundary reminder**: anything about the *doc template shape* is koni-docs';
+anything about *running* a test is gstack's; the *gate* is koni-harness'. koni-qc
+brings the method and the coverage — invoke the others, don't reproduce them.

--- a/.claude/skills/koni-qc/references/customize-network-test-cases.example.md
+++ b/.claude/skills/koni-qc/references/customize-network-test-cases.example.md
@@ -1,0 +1,230 @@
+# Test Cases — Customize Network (koni-qc pilot)
+
+> **Load when**: you want a concrete end-to-end example of an authored suite.
+> **Worked example** produced by `koni-qc` from a feature's requirements, shown
+> as one flat document for readability — a real adoption splits it per the
+> `test-cases/EPIC-CN/` directory layout of `test-organization.md` §1 (`index.md`
+> frame + per-US row files; the single-file `EPIC-CN.md` shape shown here is
+> legacy-accepted). It demonstrates the standard and the uplift over the hand-made
+> `koni-docs.backup` `customize-network` suite (58 manual cases, ~70% happy-path,
+> no TC IDs, no AC↔TC matrix, <5% NFR). The content (rows, matrix, sections) is
+> identical in either container; the product (SubWallet) is not in this repo.
+
+---
+
+**Contents**: [Overview](#overview) ·
+[Quick reference — test scenarios summary](#quick-reference--test-scenarios-summary) ·
+[Test scenarios](#test-scenarios) · [Coverage matrix (AC ↔ TC)](#coverage-matrix-ac--tc) ·
+[Open / deferred scenarios](#open--deferred-scenarios) ·
+[Self-grade vs `quality-bar.md`](#self-grade-vs-quality-barmd) ·
+[Before / after delta](#before--after-delta-vs-the-manual-backup)
+
+---
+
+## Overview
+
+### Scope
+
+**In scope** — the *Customize Network* feature (extension + mobile): add a custom
+RPC network manually, auto-detect chain metadata, edit, and delete.
+
+**Out of scope** — the underlying chain connectivity library; built-in network
+seeding; the provider-selector UI beyond "the new network appears" (its own suite).
+
+### Acceptance criteria (derived from requirements)
+
+- **AC-1** — Entering a reachable RPC URL auto-detects chain type (EVM/Substrate)
+  and auto-fills name, native symbol, decimals, chain-id, block explorer.
+- **AC-2** — The user can override any auto-filled field before saving.
+- **AC-3** — Save persists the network; it then appears in the provider/selector.
+- **AC-4** — An unreachable or invalid RPC is rejected with a clear error
+  (*"Cannot connect to this provider"*); nothing is saved.
+- **AC-5** — A network that already exists (same chain-id) is rejected as a
+  duplicate.
+- **AC-6** — A custom network can be edited and deleted; a built-in or
+  currently-in-use network cannot be deleted.
+
+### Goals — what running this suite proves
+
+A user can safely add, override, persist, edit, and remove custom networks; bad
+input fails closed; the form resists injection/SSRF; it degrades gracefully on
+flaky networks; no duplicate or orphaned network state is created.
+
+### Environment & test data
+
+- **Env**: extension (Chrome/Firefox) + mobile (iOS/Android), staging build.
+- **Fixtures** (reusable, seeded): `RPC_EVM_OK = https://rpc.evm-test.example`,
+  `RPC_SUBSTRATE_OK = wss://rpc.dot-test.example`, `RPC_UNREACHABLE =
+  https://10.255.255.1`, `RPC_MALFORMED = "ht!tp://nope"`, `NET_EXISTING` (a
+  network already imported), `NAME_MAX` (64 chars), `NAME_OVER` (65 chars),
+  `NAME_EMOJI = "Bố 🚀 net"`, `NAME_XSS = "<script>alert(1)</script>"`,
+  `RPC_INTERNAL = http://169.254.169.254/latest/meta-data`.
+- **Teardown**: delete any custom network a case created at end of run.
+
+### Cadence & ownership
+
+| Cadence | Test types | Owner |
+|---|---|---|
+| Per-PR | smoke (`SMK`) | dev on PR |
+| Per-release | functional + regression (`RC-`) + security | QA |
+| Nightly | performance (`PERF`) | CI |
+
+## Quick reference — test scenarios summary
+
+> The **AC** column lists the AC(s) each TC *touches*; for the slot role
+> (positive / negative / boundary-or-edge / NFR) see the §Coverage matrix below.
+
+| # | ID | Type | Priority | Short description | AC |
+|---|---|---|---|---|---|
+| 1 | TC-CN.SMK-1 | Smoke | Critical | Import a valid EVM RPC end-to-end | AC-1,3,5 |
+| 2 | TC-CN.FUNC-1 | Functional | Critical | Auto-detect + auto-fill (EVM); valid RPC accepted | AC-1,4 |
+| 3 | TC-CN.FUNC-2 | Functional | Critical | Auto-detect + auto-fill (Substrate) | AC-1 |
+| 4 | TC-CN.FUNC-3 | Functional | High | Override an auto-filled field, then save | AC-2 |
+| 5 | TC-CN.FUNC-4 | Functional | High | Saved network appears in selector | AC-3 |
+| 6 | TC-CN.FUNC-5 | Functional | High | Edit a custom network | AC-6 |
+| 7 | TC-CN.FUNC-6 | Functional | High | Delete a custom (not-in-use) network | AC-6 |
+| 8 | TC-CN.NEG-1 | Negative | Critical | Unreachable RPC → clear error, nothing saved | AC-1,4 |
+| 9 | TC-CN.NEG-2 | Negative | High | Malformed URL → validation error | AC-4 |
+| 10 | TC-CN.NEG-3 | Negative | High | Duplicate network (same chain-id) rejected | AC-5 |
+| 11 | TC-CN.NEG-4 | Negative | High | Cannot delete an in-use / built-in network | AC-6 |
+| 12 | TC-CN.NEG-5 | Negative | High | Storage write fails on Save → no orphan network | AC-3 |
+| 13 | TC-CN.NEG-6 | Negative | High | Override a field with an invalid type (non-numeric decimals) → rejected | AC-2 |
+| 14 | TC-CN.BND-1 | Boundary | Medium | Name at 64 (ok) / 65 (rejected) chars | AC-2 |
+| 15 | TC-CN.BND-2 | Boundary | Medium | Decimals 0 / max accepted; max+1 rejected | AC-2 |
+| 16 | TC-CN.BND-3 | Boundary | Medium | Same name, different chain-id → accepted (not a dup) | AC-5 |
+| 17 | TC-CN.BND-4 | Boundary | Medium | Rename a custom network onto an existing name → rejected | AC-6 |
+| 18 | TC-CN.SEC-1 | Security | Critical | XSS in network name is neutralized | AC-2 |
+| 19 | TC-CN.SEC-2 | Security | High | RPC URL sanitized (no SSRF to internal hosts) | AC-4 |
+| 20 | TC-CN.EDGE-1 | Edge | Medium | Emoji / non-ASCII name persists correctly | AC-2 |
+| 21 | TC-CN.EDGE-2 | Edge | High | Double-tap Save creates only one network | AC-3 |
+| 22 | TC-CN.EDGE-3 | Edge | High | Network drops mid-detect → graceful timeout | AC-1,4 |
+| 23 | TC-CN.PERF-1 | Performance | Medium | Detect completes within SLA (p95 ≤ 2.0s) | AC-1 |
+| 24 | TC-CN.A11Y-1 | Accessibility | Medium | Import form is keyboard-navigable + labelled | AC-1,2 |
+| 25 | TC-CN.REG-1 (`RC-1`) | Regression | Critical | Adding a custom network doesn't break built-ins | AC-3 |
+
+## Test scenarios
+
+Canonical rich-TC table (per koni-qc `traceability.md`).
+
+| TC-ID | Name | Priority | Test data | Preconditions | Action/Request | Expected | Actual | Status | Perf | Side-effects | Covered-by |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| TC-CN.SMK-1 | Import valid EVM RPC end-to-end | Critical | `RPC_EVM_OK` | No custom networks | Manage Network → + → paste RPC → Save | Detected EVM; fields auto-filled; saved; appears in selector | — | Not Executed | — | +1 network row | `e2e/customize-network.spec.ts::smoke` |
+| TC-CN.FUNC-1 | Auto-detect + fill (EVM); valid RPC accepted | Critical | `RPC_EVM_OK` | On import screen | Paste RPC, wait for detect | Chain=EVM; name/symbol/decimals/chain-id/explorer populated, editable; Save enabled | — | Not Executed | — | None (pre-save) | — (manual) |
+| TC-CN.FUNC-2 | Auto-detect + fill (Substrate) | Critical | `RPC_SUBSTRATE_OK` | On import screen | Paste WSS RPC | Chain=Substrate; fields populated | — | Not Executed | — | None | — (manual) |
+| TC-CN.FUNC-3 | Override auto-filled name, then save | High | `RPC_EVM_OK`, name "My EVM" | Detect succeeded | Edit name → Save | Saved network uses the overridden name | — | Not Executed | — | +1 network | — (manual) |
+| TC-CN.FUNC-4 | Saved network appears in selector | High | `RPC_EVM_OK` | Network saved (FUNC-1) | Open the provider/network selector | The new network is listed and selectable | — | Not Executed | — | None | `e2e/customize-network.spec.ts::appears` |
+| TC-CN.FUNC-5 | Edit a custom network | High | custom `NET_X` | `NET_X` is custom | Edit → change explorer URL → Save | Change persists; selector reflects it | — | Not Executed | — | 1 row updated | — (manual) |
+| TC-CN.FUNC-6 | Delete a custom (not-in-use) network | High | custom `NET_X`, not selected | `NET_X` custom + not active | Delete `NET_X` → confirm | Removed from list & store | — | Not Executed | — | −1 network row | — (manual) |
+| TC-CN.NEG-1 | Unreachable RPC rejected | Critical | `RPC_UNREACHABLE` | On import screen | Paste → wait | Error "Cannot connect to this provider"; Save disabled; nothing saved | — | Not Executed | — | **None** (assert no row) | — (manual) |
+| TC-CN.NEG-2 | Malformed URL rejected | High | `RPC_MALFORMED` | On import screen | Paste malformed | Inline validation error; no network call attempted | — | Not Executed | — | None | — (manual) |
+| TC-CN.NEG-3 | Duplicate network (same chain-id) rejected | High | RPC of `NET_EXISTING` | `NET_EXISTING` imported | Paste same RPC → Save | Rejected "Network already exists"; count unchanged | — | Not Executed | — | None | — (manual) |
+| TC-CN.NEG-4 | Cannot delete in-use / built-in | High | a built-in + the active network | A network is selected/in-use | Attempt delete | Delete blocked with explanation; network retained | — | Not Executed | — | None | — (manual) |
+| TC-CN.NEG-5 | Storage write fails on Save → no orphan | High | `RPC_EVM_OK` + injected store-write failure | Detect succeeded; store write will fail | Save | Error surfaced; **no partial/orphan network** persisted; list unchanged | — | Not Executed | — | None (assert atomic) | — (manual) |
+| TC-CN.NEG-6 | Override field with invalid type → rejected | High | decimals = `"abc"` (non-numeric) | Detect succeeded | Override decimals with a non-numeric value → Save | Rejected with a field-level validation error; nothing saved | — | Not Executed | — | None | — (manual) |
+| TC-CN.BND-1 | Name length boundary | Medium | `NAME_MAX` (64), `NAME_OVER` (65) | Detect succeeded | Save with 64 then 65 chars | 64 → saved; 65 → validation error | — | Not Executed | — | +1 (valid only) | — (manual) |
+| TC-CN.BND-2 | Decimals boundary | Medium | decimals 0, max, max+1 | Detect succeeded | Override decimals → Save | 0 & max accepted; max+1 rejected | — | Not Executed | — | +1 | — (manual) |
+| TC-CN.BND-3 | Same name, different chain-id → accepted | Medium | name of `NET_EXISTING`, new chain-id | `NET_EXISTING` imported | Add: same name, different chain-id → Save | Accepted (uniqueness is chain-id, not name) | — | Not Executed | — | +1 network | — (manual) |
+| TC-CN.BND-4 | Rename onto an existing name → rejected | Medium | custom `NET_X`, name of `NET_EXISTING` | both exist | Edit `NET_X` → set name = existing → Save | Rejected with a name-collision error; `NET_X` unchanged | — | Not Executed | — | None | — (manual) |
+| TC-CN.SEC-1 | XSS in name neutralized | Critical | `NAME_XSS` | Detect succeeded | Set name = `<script>…` → Save → view in selector | Stored & rendered as inert text; no script executes | — | Not Executed | — | +1 (sanitized) | `e2e/customize-network.spec.ts::xss-name` |
+| TC-CN.SEC-2 | RPC URL sanitized (no SSRF) | High | `RPC_INTERNAL`, `http://localhost:…` | On import screen | Paste internal-host URL | Blocked; not dialed to internal metadata / loopback | — | Not Executed | — | None | — (manual) |
+| TC-CN.EDGE-1 | Emoji / non-ASCII name | Medium | `NAME_EMOJI` | Detect succeeded | Save emoji name → reopen | Persists & displays correctly (UTF-8); no mojibake | — | Not Executed | — | +1 | — (manual) |
+| TC-CN.EDGE-2 | Double-tap Save idempotent | High | `RPC_EVM_OK` | Detect succeeded | Tap Save twice quickly | Exactly **one** network created; button locks after first | — | Not Executed | — | +1 (not +2) | — (manual) |
+| TC-CN.EDGE-3 | Network flaky mid-detect | High | `RPC_EVM_OK` + throttle→offline | Detect in progress | Drop connection during detect | Graceful timeout + retryable error; no half-saved state | — | Not Executed | — | None | — (manual) |
+| TC-CN.PERF-1 | Detect within SLA | Medium | `RPC_EVM_OK` | On import screen | Measure detect time | p95 ≤ **2.0 s** on staging | — | Not Executed | target 2.0s | None | `perf/detect.bench` |
+| TC-CN.A11Y-1 | Form keyboard + labels | Medium | — | On import screen | Tab through form; screen-reader | Inputs reachable by keyboard, labelled, logical focus order, errors announced | — | Not Executed | — | None | — (manual) |
+| TC-CN.REG-1 | Built-ins intact after add (`RC-1`) | Critical | `RPC_EVM_OK` | Built-in networks present | Add a custom network | All built-in networks still present & selectable | — | Not Executed | — | +1 | `e2e/customize-network.spec.ts::regress` |
+
+## Coverage matrix (AC ↔ TC)
+
+Every AC has ≥1 positive **and** ≥1 negative **and** ≥1 boundary-or-edge case,
+each filled by a **distinct** TC (no double-counting) — the check the manual
+backup suite lacked entirely. No orphan AC; no orphan TC.
+
+> **Single-feature suite → one US block.** This worked example is a single
+> customize-network feature, so the matrix collapses to one story block and omits
+> the per-US **Story** column that [`traceability.md`](traceability.md) shows for a
+> multi-story epic. In a real `EPIC-NN.md` the matrix has a leading `Story` column
+> (one block per US) and every TC carries `maps_to.us` — coverage is then measured
+> per US (`test-organization.md` §0). Here every TC `maps_to.us: US-CN` (the
+> customize-network story).
+
+| AC | AC description | Positive | Negative | Boundary / edge | NFR |
+|---|---|---|---|---|---|
+| AC-1 | Auto-detect + auto-fill | TC-CN.FUNC-1, FUNC-2, SMK-1 | TC-CN.NEG-1 | TC-CN.EDGE-3 | TC-CN.PERF-1, A11Y-1 |
+| AC-2 | Override fields | TC-CN.FUNC-3 | TC-CN.NEG-6 | TC-CN.BND-1, BND-2, EDGE-1 | TC-CN.SEC-1, A11Y-1 |
+| AC-3 | Persist + appears in selector | TC-CN.FUNC-4, SMK-1, REG-1 | TC-CN.NEG-5 | TC-CN.EDGE-2 | — |
+| AC-4 | Reject invalid / unreachable RPC | TC-CN.FUNC-1 (valid accepted) | TC-CN.NEG-1, NEG-2 | TC-CN.EDGE-3 | TC-CN.SEC-2 |
+| AC-5 | Reject duplicate | TC-CN.SMK-1 (new accepted) | TC-CN.NEG-3 | TC-CN.BND-3 | — |
+| AC-6 | Edit / delete rules | TC-CN.FUNC-5, FUNC-6 | TC-CN.NEG-4 | TC-CN.BND-4 | — |
+
+**Every AC row has a distinct positive, negative, and boundary-or-edge TC** (AC-1,
+AC-3, AC-4 use an EDGE case for the third slot — explicitly allowed by the
+[`traceability.md`](traceability.md) "boundary-or-edge" rule). Each TC in the
+matrix exists as a row in §Test scenarios (no orphan TC); each AC is covered (no
+orphan AC). Regression baseline = the `RC-` set: **RC-1** (TC-CN.REG-1), run
+every release.
+
+## Open / deferred scenarios
+
+- App-kill mid-Save durability (process crash between detect and persist) —
+  deferred to a dedicated resilience pass (related to NEG-5).
+- i18n: RTL rendering of the network name — deferred (tracked in `nfr.md` §i18n).
+
+## Self-grade vs `quality-bar.md`
+
+**Band A — beat the manual backup (all must clear):**
+- [x] Explicit TC IDs — `TC-CN.<TYPE>-<n>`
+- [x] AC↔TC matrix — complete; every AC has a distinct pos + neg + boundary-or-edge; no orphans, no double-counting
+- [x] ≥50% off-path — 6 NEG + 4 BND + 3 EDGE = 13 of 25 cases (52%) off-path
+- [x] NFR present — SEC-1/2, PERF-1, A11Y-1
+- [ ] Coverage % reported — **N/A for this authoring artifact** (execution item;
+  satisfied at Execute when the run reports % by AC/type). The authoring AC↔TC
+  matrix itself is the row above.
+- [x] Test-data strategy — named reusable fixtures + teardown
+- [x] Entry/exit criteria — `qc-workflow.md`; release gate on matrix + RC set
+- [x] Test lifecycle — Open/deferred; deprecate-not-renumber per scheme
+- [x] Risk-based order — Critical→Low priorities
+- [x] Regression scope — `RC-1` baseline
+- [x] Automation linkage — Covered-by column (`*.spec.ts` / `bench` handles)
+- [ ] Real reports — **N/A for this authoring artifact** (all 25 rows are `Not
+  Executed`); satisfied at the Execute stage when the koni-docs `test-report.md`
+  is filled. Per `quality-bar.md`, the two execution-stage Band-A items (Real
+  reports + Coverage % reported) are deferred-not-failed for an Author-mode suite.
+
+**Band B — match the Koni-Finance standard:**
+- [x] Rich per-TC metadata table (12 columns)
+- [x] Dedicated security cases (SEC-1 XSS, SEC-2 SSRF; can emit a standalone `*-security-test-cases.md`)
+- [x] Concrete reusable test data (fixtures block)
+- [x] Execution instrumentation (Status + Perf + Side-effects + Covered-by)
+
+**Band C — close its residual gaps:**
+- [x] **Complete** AC↔TC matrix (Koni-Finance lacked this)
+- [x] Env/fixtures playbook (Environment & test data)
+- [x] a11y/i18n (A11Y-1, EDGE-1; i18n deferred-but-logged)
+- [x] Perf SLA (PERF-1 p95 ≤ 2.0s — a target, not just a measurement)
+- [x] Cadence (Cadence & ownership table)
+
+**Pass rule** — clears all of Band A; demonstrably exceeds B and C. ✅ **PASS.**
+
+---
+
+## Before / after delta vs the manual backup
+
+| Dimension | `koni-docs.backup` (manual) | This (koni-qc) |
+|---|---|---|
+| Test IDs | none (row # + name) | explicit `TC-CN.<TYPE>-<n>` |
+| AC↔TC traceability | implicit (feature name) | **complete coverage matrix**, no orphans |
+| Negative / boundary | ~25%, ad-hoc | NEG/BND/EDGE first-class (~50%) |
+| Injection / security | absent | SEC-1 (XSS), SEC-2 (SSRF) |
+| Concurrency / network-failure / durability | absent | EDGE-2 (double-save), EDGE-3 (flaky), NEG-5 (atomic save) |
+| Non-functional | absent | PERF-1 (SLA), A11Y-1 |
+| Test data | hardcoded, scattered | named reusable fixtures + teardown |
+| Risk ordering | equal (row order) | Critical→Low |
+| Regression scope | undefined | `RC-1` baseline |
+
+58 shallow manual cases → **25 typed, traced, risk-ordered, edge/NFR/security-complete**
+cases that pass koni-qc's own quality bar — the same feature, covered to a standard
+the manual suite never reached, and to a completeness (full AC↔TC matrix) the
+Koni-Finance production suite did not have either. A full production suite expands
+each AC's partitions further per `test-design.md`; this pilot establishes the
+shape and clears the bar.

--- a/.claude/skills/koni-qc/references/edge-coverage.md
+++ b/.claude/skills/koni-qc/references/edge-coverage.md
@@ -1,0 +1,65 @@
+# edge-coverage — the edge-case taxonomy
+
+> **Load when**: you have a happy-path case list and need to make it *thorough*
+> (the **Design** stage of [`qc-workflow.md`](qc-workflow.md)). This is the
+> headline fix for the backup's "~70% happy-path" gap: run every feature through
+> the taxonomy below and you cannot ship a suite that only tests the sunny day.
+> Pairs with [`test-design.md`](test-design.md) (the derivation techniques) and
+> feeds [`traceability.md`](traceability.md) (the negative/boundary half of the
+> AC↔TC matrix).
+
+**Contents**: [The edge-case taxonomy](#the-edge-case-taxonomy) · [How to apply](#how-to-apply)
+
+The backup suite's single largest defect was distribution: ~70% of its cases
+exercised the happy path, ~25% were thin negatives, and edge classes
+(injection, encoding, concurrency, network failure) were essentially absent. A
+feature is not "tested" because the demo works; it is tested when it survives
+the inputs a real user — or attacker — throws at it. This taxonomy is the
+checklist that makes that survival auditable.
+
+---
+
+## The edge-case taxonomy
+
+Run **every feature** through every row. For each row, either write the case or
+record in the suite's *Open / deferred* section why it does not apply. Each row
+names the backup gap it closes so the uplift is traceable.
+
+| # | Edge class | What to probe | Backup gap it closes | One-line example case |
+|---|---|---|---|---|
+| 1 | **null / empty / zero / max / overflow** | absent value, empty string, `0`, the documented max, and one past it | thin boundary coverage (~25% negatives, no `min/max±1`) | decimals = `0` accepted; decimals = `19` rejected |
+| 2 | **malformed / encoding / emoji / i18n** | wrong format, non-ASCII, emoji, RTL, combining chars, surrogate pairs | no encoding/i18n cases at all | network name `日本語🌐` stored + rendered intact |
+| 3 | **injection / XSS / special-chars** | `<script>`, quotes, `;`, SQL-ish, template `${}`, path `../` | no security/injection cases (<5% non-functional) | name `<script>alert(1)</script>` escaped, never executed |
+| 4 | **concurrency / double-submit / race** | double-tap submit, parallel edits, fast retry, simultaneous saves | no concurrency cases | double-tap Save → exactly one network created |
+| 5 | **permission / auth / ownership** | act without auth, on another's resource, on a protected/in-use item | no authz cases | delete an in-use/active network → refused |
+| 6 | **network flaky / offline / timeout / retry** | slow response, mid-request drop, offline, retry storm | no resilience cases | RPC auto-detect times out → clear error, no half-saved state |
+| 7 | **state / lifecycle transitions** | every legal transition + the illegal ones | no state-machine coverage | edit a network after it was deleted in another tab → graceful refusal |
+| 8 | **timezone / locale** | DST edge, UTC vs local, locale number/date format, 12/24h | no tz/locale cases | decimals parsed with locale `,` decimal separator |
+| 9 | **idempotency** | replay the same request/action twice | no idempotency cases | re-Save unchanged network → no duplicate, no error |
+| 10 | **pagination / large-data** | empty list, one item, page boundary, very large list | no large-data cases | provider list with 500 networks scrolls + filters within SLA |
+
+---
+
+## How to apply
+
+1. **Run the full list, every feature.** The taxonomy is a gate, not a buffet.
+   A row you skip must be justified in the suite's *Open / deferred scenarios*
+   with an owner — silence is a gap, not a pass.
+2. **Budget ≥50% off-path.** Across the finished suite, at least half the cases
+   must be **off-path = negative (NEG) + boundary (BND) + edge (EDGE)**, not
+   happy-path. This is a [`quality-bar.md`](quality-bar.md) Band-A item and is
+   checked in self-review. The backup sat near 25%; the pilot lands at or above 50%.
+3. **Map each edge case to its AC and TYPE.** An injection case is `TC-*.SEC-*`;
+   a **concurrency / network-failure / encoding / state-race** case is `TC-*.EDGE-*`
+   (the `EDGE` TYPE per [`traceability.md`](traceability.md)) — record it in the
+   canonical table with the right TYPE so it counts in the AC↔TC matrix.
+4. **Escalate the security and NFR rows.** Rows 3, 5, and 6 frequently graduate
+   into the dedicated coverage in [`nfr.md`](nfr.md) (§Security, §Reliability) —
+   when risk is high, emit a standalone `*-security-test-cases.md` rather than
+   burying them.
+5. **Prove it in the matrix.** Every AC must come out of this pass with a
+   **boundary-or-edge** case — a value boundary (`BND`, e.g. rows 1, 8, 10) *or* an
+   `EDGE` case (concurrency / network-failure / state-race, e.g. rows 4, 6, 7) — **and**
+   a **negative** case (invalid input / permission, e.g. rows 2, 3, 5, 9), or the
+   AC↔TC matrix in [`traceability.md`](traceability.md) fails. (EDGE rows fill the
+   boundary-or-edge slot, not the negative slot.)

--- a/.claude/skills/koni-qc/references/layered-suites.md
+++ b/.claude/skills/koni-qc/references/layered-suites.md
@@ -1,0 +1,207 @@
+# layered-suites — author the suite by layer, to the exemplar bar
+
+> **Load when**: authoring test cases for a US/epic that has an **API surface and/or a
+> UI** — this is the structure standard that lifts a suite from "one flat table" to the
+> exemplar bar (synthesized from the US-001.001 API + functional exemplar suites and the
+> SubWallet checklist-round practice in `koni-docs.backup`). It builds ON the method
+> refs: [`test-design.md`](test-design.md) derives the cases, [`traceability.md`](traceability.md)
+> owns TC-IDs + the AC↔TC matrix — **this file owns how the suite document is layered,
+> shaped, and cross-checked**.
+
+**Contents**: [The two layers](#the-two-layers) ·
+[API suite standard](#api-suite-standard) ·
+[Functional suite standard](#functional-suite-standard) ·
+[Orthogonal coverage matrices](#orthogonal-coverage-matrices) ·
+[Named test-data registry](#named-test-data-registry) ·
+[Open questions](#open-questions) ·
+[Round-based bug-fix retest](#round-based-bug-fix-retest) · [Ownership](#ownership)
+
+---
+
+## The two layers
+
+Split a mixed-surface US into **two sibling case files** with a mutual scope contract —
+one flat table forces API detail and UI detail into the same columns and both suffer:
+
+| Layer | File | Proves | Excludes (and says so) |
+|---|---|---|---|
+| **API** | `US-X.Y-api-test-cases.md` (or the epic file's §API) | endpoints, auth, RLS/permissions, events, audit, DB effects | UI interactions, visual feedback, client state |
+| **Functional / UI** | `US-X.Y-functional-test-cases.md` (or §Functional) | UI flows, validation feedback, states, a11y, visual conformance | endpoint responses, DB records, event publishing |
+
+Each file **opens with "What is tested" + "Out of scope (covered in <the other file>)"** —
+the pair of scope blocks is the contract that nothing falls between the layers. Once the
+suite has run, each file also carries a **per-doc execution summary** under its scope
+block — the full counter set of [`test-automation.md`](test-automation.md) §2 (total ·
+pass · fail · blocked · broken · env-pending · design · not-written · manual ·
+ops-deploy, + %; buckets sum to total), written back from the run
+(the exemplar docs each open with theirs; a suite doc with no summary after a run reads
+as never-executed). Both
+layers share one TC-ID space and one AC↔TC matrix (`maps_to.us` unchanged); the split is
+*presentation + column shape*, not a second numbering scheme.
+
+**Where the files live + when to split.** Under the per-US layout
+([`test-organization.md`](test-organization.md) §1) the layered pair are siblings
+**inside the epic dir**: `test-cases/EPIC-N/US-x.y-api.md` +
+`US-x.y-functional.md`, linked from that story's `US-x.y.md` row file and indexed in
+`index.md` (same placement rule as the `<feature>-security-test-cases.md` split in
+[`quality-bar.md`](quality-bar.md) Band B, which composes with this one). Split into
+files when a layer exceeds ~15 cases; below that, keep `§API` / `§Functional`
+sections inside `US-x.y.md`. (Legacy single-file repos: siblings sit next to
+`EPIC-NN.md` as before.) The reporter's spec-reconcile scan is **recursive over
+`test-cases/`** ([`test-automation.md`](test-automation.md) §2), but an unlinked
+stray file is still invisible to a *reader* — always index it. Distinct from these
+**authoring** docs: the per-run `test-reports/YYYY-MM-DD/EPIC-N/US-x.y/
+{api,functional}-test-cases.md` are **generated execution instantiations** of the
+same suites (reporter-written, never hand-edited).
+
+## API suite standard
+
+Organize **by endpoint** — one section + one summary table per endpoint (`POST /api/v1/…`),
+so a reader audits an endpoint's coverage at a glance.
+
+- **Columns** (the canonical table reshaped for APIs — `Response Time (ms)` **is** the
+  canonical `Perf` column and `DB Changes` **is** `Side-effects`, renamed; a quality-bar
+  "full canonical table" check accepts these renames): `TC ID · Name · Priority ·
+  Test Data · Preconditions · Request Headers · Request Payload · Expected Response ·
+  Actual Response · Status · Response Time (ms) · DB Changes · Covered-by`.
+  - **Actual Response is the real body** (actual JSON, truncated sensibly) — never a
+    paraphrase and never a copy of Expected (see [`report-quality.md`](report-quality.md)
+    §Honest actuals).
+  - **DB Changes** names the tables/rows the call touched (`users, user_wallets` /
+    `No changes`) — it is the side-effects column made concrete for APIs.
+  - Worked row (one line, real values — keep payloads/bodies tight):
+
+    | TC ID | Name | Priority | Test Data | Preconditions | Request Headers | Request Payload | Expected Response | Actual Response | Status | Response Time (ms) | DB Changes | Covered-by |
+    |---|---|---|---|---|---|---|---|---|---|---|---|---|
+    | TC-01.WS-5 | Create workspace — wallet not owned | High | wallet `0xffff…9999` (User C's) | authed as User A | `Authorization: Bearer <JWT>` | `{ name, primaryWalletAddress: "0xffff…" }` | HTTP 403 `WALLET_NOT_OWNED` | `{"statusCode":403,"error":"WALLET_NOT_OWNED","message":"Wallet address is not owned…"}` | Pass | 78 | No changes | `epic/EPIC-01/workspaces.integration.spec.ts::TC-01.WS-5` |
+- **Endpoint-group prefixes live in the TYPE slot of the canonical ID** — the domain-prefix
+  allowance of [`traceability.md`](traceability.md): `TC-01.WS-1`, `TC-01.JOIN-4`,
+  `TC-01.RLS-7`. Everything machine-read — **generated test names, `Covered-by`,
+  `maps_to`, the reporter** — carries **only** the canonical `TC-<EPIC>.<TYPE>-<n>` form
+  (the parse rule of [`test-automation.md`](test-automation.md) §2 depends on it). A short
+  display alias (`WS-001`) MAY be used inside the doc's endpoint tables for scannability,
+  but then the suite MUST carry an **alias → canonical TC-ID mapping table** in its
+  traceability section, and the alias never appears in code or reports — two live ID
+  spaces with an informal map is exactly the ERP F-12 collision
+  ([`test-organization.md`](test-organization.md) §3).
+- **Required API coverage classes** — a US with an API surface is not covered without
+  each of these sections (mark N/A explicitly if truly absent; these are *structure*
+  slots — the case content inside them derives from [`nfr.md`](nfr.md) §Security +
+  [`test-design.md`](test-design.md), stated once there):
+  1. **Auth guard** — expired / missing / malformed / wrong-issuer token **× every
+     protected endpoint** — the case count multiplies per endpoint (each endpoint's
+     guard is a separate implementation risk; `test-design.md` step 9); only the
+     *document placement* is shared (one Auth Guard section holding all the rows,
+     not the prose duplicated per endpoint).
+  2. **RLS / permission isolation** — per protected table: owner-scoped read, cross-user
+     isolation (the *other* user's rows do NOT appear), and client write-rejection.
+  3. **Events / messaging** — each domain event: emitted-on-trigger, payload shape,
+     idempotency under rapid duplicates.
+  4. **Audit / compliance** — the audit trail rows (who/when/IP/agent, failed attempts
+     recorded with reason).
+
+## Functional suite standard
+
+- **Category prefix in every case name** — a **closed set of four**, mapped from the
+  scenario (the TC-ID TYPE still classifies the case; they coexist):
+  `[Happy Path]` = the primary success flow (FUNC/E2E/SMK/API positives) ·
+  `[Error]` = a failure/rejection path (NEG, SEC rejections, network/server errors) ·
+  `[Validation]` = an input-rule check incl. its boundaries (BND + form-validation NEG) ·
+  `[Verification]` = a state/feedback/display assertion after an action (badges, toasts,
+  persistence, disabled-during-submit, A11Y checks). Don't invent a fifth.
+- **UI-component traceability** — the traceability table carries a `UI Component` column
+  (Login page · Workspace switcher · Toast…), enabling the per-component rollup below.
+- **Evidence per executed case** — a dedicated **Evidence/Note column** (NOT `Covered-by`,
+  whose five fixed forms are [`traceability.md`](traceability.md)'s and must not be
+  extended) links the runner spec `file:line` **and** the artifact (video/screenshot
+  path) for every failure, so a fail is replayable without re-running
+  (`e2e/us001.spec.ts:214; …/img/TC-….webm` — artifacts live in the run folder per
+  [`report-quality.md`](report-quality.md) §Evidence rule).
+- **State/feedback verification is first-class** — disabled-during-submit, loading
+  states, toasts (success + error), empty states, keyboard/a11y — derived via
+  [`test-design.md`](test-design.md) but *listed* so they aren't dropped as "polish".
+
+## Orthogonal coverage matrices
+
+The AC↔TC matrix proves *requirements* coverage; these matrices prove **surface**
+coverage — cheap tables that catch whole missing classes the AC axis can't see. Include
+the ones that apply; each is "enumerate the full set → map TCs → a set member with no TC
+is a visible gap":
+
+| Matrix | Enumerate | For |
+|---|---|---|
+| **Endpoint coverage** | every endpoint × its TC count | API |
+| **HTTP status-code coverage** | every status the design can return (200/201/400/401/403/404/409/410/413/415/5xx) → the TCs that assert it | API |
+| **Error-code coverage** | every error code in the design (`WALLET_NOT_OWNED`, …) → the TCs that assert it | API |
+| **Field × validation coverage** | rows = input fields; cols = {empty · min−1 · min · max · max+1 · wrong-type · format · injection} — **every cell a TC-ID or an explicit N/A** | API + Functional |
+| **State-transition coverage** | every legal transition AND every illegal attempt → its TC | API + Functional |
+| **Page coverage** | every page/route → its TCs | Functional |
+| **Component coverage** | every UI component touched → its TCs | Functional |
+| **Validation + a11y coverage** | every validation rule; keyboard/screen-reader/focus | Functional |
+
+A status/error code with zero TCs = an untested contract branch; a page with zero TCs =
+an untested surface. These live in the suite's Traceability section next to the AC↔TC
+matrix.
+
+## Named test-data registry
+
+One section registering every fixture **by name with a "Used In" back-reference**
+(wallet/account/token/workspace → owner, state, the TCs that use it):
+
+| Fixture | State | Used in |
+|---|---|---|
+| `0xabcd…2222` | owned, **unverified** | WS-006, JOIN-008 |
+| `invite-expired-002` | expired | JOIN-004 |
+
+The registry makes collisions visible (two TCs mutating one fixture), makes runs
+reproducible, and is where **acquisition notes** live ("how to get a funded test account
+on network X" — the backup's *Cách lấy data* guideline pattern). This implements
+[`qc-workflow.md`](qc-workflow.md) §Test-data & fixtures strategy at the artifact level.
+
+## Open questions
+
+Every spec ambiguity the derivation surfaces becomes a **checkbox in an `## Open
+Questions` section** of the suite — named, specific, and pointing at the doc that must
+answer it ("GIF avatar support — TD only shows PNG/JPEG; confirm accepted MIME types").
+The section also holds **recorded derivation-scope justifications** (e.g. why a small US
+legitimately sits under the density sanity of [`qc-workflow.md`](qc-workflow.md) §3).
+Never resolve an ambiguity silently inside a TC's Expected: the suite records the
+assumption *and* the open question, and Frame routes it back as a PRD/story gap
+([`qc-workflow.md`](qc-workflow.md) §1).
+
+## Round-based bug-fix retest
+
+The backup's matured practice for verifying fix batches (distinct from `RC-` regression
+cases, which guard *shipped* invariants every release):
+
+- A feature's bug-fix verification runs in **numbered rounds** (`[Round 1] <feature>`,
+  `[Round 2] …`), each a checklist of the bugs found, re-verified against a **named
+  build**.
+- Each bug entry is an **Actual vs Expect pair + evidence** (screenshot/GIF/log link) —
+  not a bare "broken" line — and links the design source (Figma/DESIGN.md) when visual.
+- A bug re-opened in round N+1 stays on the list with its re-repro evidence; the round
+  is clean only when every entry verifies. New rounds open until clean, then each
+  surviving invariant graduates to a `TC-<EPIC>.REG-<n>` case tagged `RC-<n>` **citing
+  the bug it guards** ([`traceability.md`](traceability.md)).
+- **Where rounds live**: each round is a manual verification run → its checklist is the
+  `report-manual.md` of a dated run folder
+  (`test-reports/YYYY-MM-DD/EPIC-N/report-manual.md`, evidence in `img-manual/`), and
+  any bug still open at round end is mirrored in `docs/tests/findings.md` until fixed
+  ([`test-organization.md`](test-organization.md) §1).
+- **The suite is living — every round bug feeds a spec case back.** Each bug found in a
+  round adds (or sharpens) a case in `test-cases/` **before** graduation — the case that
+  *would have caught it* — so the suite accretes with every round instead of staying a
+  one-shot Design artifact. **The fed-back case IS normally the one that graduates**
+  (it gains the `REG` type / `RC-` tag citing the bug) — don't author a second case for
+  the same invariant. This is how the backup's checklists grew to their real density:
+  bugs → cases, round after round.
+
+## Ownership
+
+This file owns the **suite structure + cross-check standard**. It composes, never
+replaces: [`test-design.md`](test-design.md) (derivation), [`traceability.md`](traceability.md)
+(TC-ID scheme, AC↔TC matrix, Covered-by forms), [`nfr.md`](nfr.md) (NFR + UI-conformance
+criteria), [`test-organization.md`](test-organization.md) (where files live),
+[`test-automation.md`](test-automation.md) (generation + reporter), koni-docs
+`templates/test-cases.md` (the container). Report content is
+[`report-quality.md`](report-quality.md).

--- a/.claude/skills/koni-qc/references/live-harness.md
+++ b/.claude/skills/koni-qc/references/live-harness.md
@@ -1,0 +1,99 @@
+# live-harness — standing up the live-stack test harness (integration + e2e)
+
+> **Load when**: integration/e2e tests need a **real running stack** (live DB with
+> RLS, a browser against a real build) and none exists yet — "how do I test RLS as a
+> user?", "stand up the integration harness", "e2e can't log in", "supabase won't
+> boot for tests". This was the single biggest automation blocker in the ERP
+> 9.3%→100% drive; these are the proven recipes, stated as a **stack-neutral pattern**
+> with the Koniverse default stack (Supabase + Next.js + Playwright) as the worked
+> example. [`test-automation.md`](test-automation.md) owns *running + reporting*;
+> this file owns *making the stack testable at all*.
+
+**Contents**: [The pattern](#the-pattern-four-properties) ·
+[Integration: test RLS as a real user](#integration-test-rls-as-a-real-user-the-2-credential-recipe) ·
+[Per-test tenant isolation](#per-test-tenant-isolation-parallel-safe-seeding) ·
+[e2e: self-seeding](#e2e-self-seeding-never-gate-on-hand-configured-secrets) ·
+[Boot resilience](#boot-resilience) · [Safety rules](#safety-rules-non-negotiable) ·
+[Ownership](#ownership)
+
+---
+
+## The pattern (four properties)
+
+Whatever the stack, the harness must deliver:
+
+1. **Authority split** — a privileged client for *seeding* + a user-scoped credential
+   for *asserting* (permissions must be evaluated as the user, never as admin).
+2. **Isolation per test** — each test seeds its own tenant/workspace so one shared
+   local DB is parallel-safe.
+3. **Self-sufficiency** — the suite creates everything it needs (users, data, env) in
+   its own setup; it never depends on a hand-configured secret or a pre-clicked UI.
+4. **Skip, don't error** — when the live env is absent (a DB-less CI lane, a fresh
+   clone), the suite **skips with a message**, it does not fail the run. The inverse
+   holds in the **designated live CI lane**: there, env-absent / all-live-suites-skipped
+   is a **red** run ([`test-automation.md`](test-automation.md) §4) — otherwise a
+   misconfigured env greens a gate that asserted nothing live.
+
+## Integration: test RLS as a real user (the 2-credential recipe)
+
+RLS/permission tests are meaningless through a service-role connection (it bypasses
+policy). The recipe:
+
+- `serviceClient()` — service-role key, **bypasses RLS — used ONLY for seeding and
+  cleanup**, never inside an assertion.
+- `userClient(userId)` — the anon key **plus a hand-minted HS256 JWT** signed with the
+  local stack's known JWT secret, `sub = userId` — so every query evaluates policy
+  **as that user**. This is what turns "RLS exists" into "RLS is asserted": owner-read,
+  cross-tenant isolation (the other user's rows do NOT appear), and client
+  write-rejection, per table ([`layered-suites.md`](layered-suites.md) required class 2).
+- `hasIntegrationEnv` guard — no env → `describe.skip` with a reason (property 4).
+
+## Per-test tenant isolation (parallel-safe seeding)
+
+Create a **fresh auth user per test** via the admin API and let the app's own
+provisioning path (e.g. a `handle_new_user` trigger) build the isolated
+workspace/tenant — then seed rows into *that* tenant and clean up in `afterAll`. One
+shared local DB, zero cross-test interference, and the provisioning path itself gets
+exercised on every run. Never share a seeded tenant across test files.
+
+## e2e: self-seeding (never gate on hand-configured secrets)
+
+- **Create the e2e user in-workflow** (a `seed-e2e` script run in setup) — a suite that
+  needs a human to pre-create an account is not automated.
+- **Point the build at the local stack with a gitignored env override** (e.g.
+  `.env.test.local` overriding `NEXT_PUBLIC_*`) — build, then `next start`. **Never
+  edit the committed/prod `.env`** to do this.
+- **Log in once, reuse the session** — a `setup` project performs the real login and
+  persists `storageState`; the browser project reuses it (fast, and the login flow
+  itself is still covered once per run).
+
+## Boot resilience
+
+Boot only what the tests need. Worked example (Supabase local):
+
+```sh
+supabase start -x edge-runtime -x vector -x imgproxy -x studio -x logflare
+```
+
+The non-essential containers — especially `edge-runtime` — can fail on unrelated
+network fetches and **roll back the whole stack**; excluding them made boot
+deterministic in the field. General rule: a flaky *optional* service must never be
+able to kill the *required* stack.
+
+## Safety rules (non-negotiable)
+
+- Apply migrations to the **local** DB directly (`docker exec … psql` or the local
+  migration command) — **never** a push command that targets the linked/prod project
+  (`db push` class).
+- **Never seed against an env that points at prod.** Check the URL before seeding;
+  a guard in the seed script beats a memory.
+- Secrets for the local stack are the stack's *known local* defaults or gitignored
+  overrides — never prod credentials copied down.
+
+## Ownership
+
+koni-qc owns these **harness recipes** (the pattern + the worked Koniverse-stack
+example). The repo owns its concrete `tests/integration/helpers.ts` / seed scripts;
+[`test-automation.md`](test-automation.md) §4–§5 owns wiring the resulting suites into
+CI (a job with services + self-seed — a container build can't host a DB/browser);
+stack-specific depth beyond the default stack belongs in that stack's plugin skill.

--- a/.claude/skills/koni-qc/references/nfr.md
+++ b/.claude/skills/koni-qc/references/nfr.md
@@ -1,0 +1,155 @@
+# nfr — non-functional coverage (security-led)
+
+> **Load when**: the **Design** stage of [`qc-workflow.md`](qc-workflow.md) needs
+> the non-functional cases that the backup corpus almost entirely lacked (<5%).
+> Functional + edge coverage is necessary but not sufficient — a feature that is
+> correct can still be insecure, slow, inaccessible, or unobservable. Security
+> leads because it is where the highest-blast-radius defects hide.
+>
+> Each section is a tight checklist plus a **required when** risk trigger. Apply a
+> section only when its trigger fires — not every feature needs every category.
+
+**Contents**: [Security](#security) · [Performance](#performance) ·
+[Accessibility](#accessibility) · [UI / visual conformance to DESIGN.md + the shadcn standard](#ui--visual-conformance-to-designmd--the-shadcn-standard) ·
+[Internationalization](#internationalization) · [Reliability & resilience](#reliability--resilience) ·
+[Compatibility](#compatibility) · [Observability](#observability)
+
+---
+
+## Security
+
+The lead. Codifies the Koni-Finance dedicated security suite. Every case here is
+a `TC-<EPIC>.SEC-<n>` row in the canonical table ([`traceability.md`](traceability.md)).
+
+- [ ] **Authn** — valid/invalid/expired credentials; session fixation; logout invalidates.
+- [ ] **Authz** — every protected path tested as owner / other-user / anonymous; no horizontal or vertical privilege escalation.
+- [ ] **Token storage & rotation** — at-rest location, expiry, refresh, revocation; no token in URL/log.
+- [ ] **CSRF / SameSite** — state-changing request without/with forged token rejected; cookie flags asserted.
+- [ ] **Replay / nonce** — a captured request replayed is rejected; nonce single-use.
+- [ ] **Rate-limiting** — burst past the limit is throttled (429); limit resets.
+- [ ] **RLS / data-isolation** — tenant A cannot read or mutate tenant B's rows.
+- [ ] **Input injection** — SQLi, XSS (stored + reflected), command/path injection on every input; output rendered escaped.
+
+> **Required when**: any feature with authentication, money/asset movement,
+> multi-tenant data, or untrusted input. When the suite has ≥5 SEC cases, emit a
+> standalone **`<feature>-security-test-cases.md`** alongside the epic file.
+
+---
+
+## Performance
+
+Assert against an **SLA target**, not just a measured number — a green run with
+no budget proves nothing.
+
+- [ ] **Latency** — p50 / p95 / p99 vs budget (e.g. p95 read < 300 ms, write < 800 ms).
+- [ ] **Throughput** — sustained req/s at target concurrency without error-rate climb.
+- [ ] **Payload / cold start** — bundle size, first-load, cold-path budget.
+- [ ] **Resource ceilings** — memory / CPU under load stays within limit.
+
+The asserted SLA goes in the canonical table's **Perf** column.
+
+> **Required when**: a user-facing latency expectation, a hot path, or a documented
+> SLA exists. Default p95 budget if unstated: interactive < 1 s, background < 5 s.
+
+---
+
+## Accessibility
+
+WCAG 2.1 AA as the floor.
+
+- [ ] **Keyboard nav** — every action reachable and operable without a mouse; no trap.
+- [ ] **Screen-reader labels** — controls, images, and live regions have accessible names.
+- [ ] **Contrast** — text ≥ 4.5:1, large text / UI ≥ 3:1.
+- [ ] **Focus order** — logical, visible focus ring; modal returns focus on close.
+
+> **Required when**: any user-facing UI. A11Y cases are `TC-<EPIC>.A11Y-<n>`.
+
+---
+
+## UI / visual conformance to DESIGN.md + the shadcn standard
+
+The visual contract has **two mandatory halves**: the repo's `DESIGN.md` (the
+product's own spec) **and** the **shadcn standard** (the Koniverse UI component
+standard, vendored by koni-setup for UI repos). A feature that "works" but drifts
+from *either* is a defect. **Every UI-bearing case MUST pass gstack `/design-review`
+against both** — this is a hard requirement, not advisory.
+
+- [ ] **DESIGN.md conformance** — run gstack `/design-review` against the repo's
+  `DESIGN.md` and confirm layout, spacing, type hierarchy, color tokens, component
+  states (hover/focus/disabled/loading/empty/error), and motion match the spec.
+- [ ] **shadcn conformance (MUST)** — the UI is built from **shadcn/ui primitives**
+  (don't hand-roll a component shadcn already provides), uses the repo's **design
+  tokens / theme** (Tailwind CSS variables + `components.json`, never ad-hoc hex/px
+  or inline restyle that bypasses the token system), expresses variants with **`cva`
+  + `cn()`** (not one-off className soup), and **preserves the Radix a11y** of the
+  primitive (keyboard, focus, ARIA). The component contracts in the repo's
+  `DESIGN.md` / design-spec name these shadcn primitives.
+- [ ] **No AI-slop / off-system patterns** — flag generic or off-system UI (a
+  re-invented button, a bespoke modal, a stray palette) that `/design-review` surfaces.
+- [ ] **Static design lint green (when the repo has one)** — the deterministic
+  subset (token-only colors — no inline hex / off-token `bg-[#…]`, typography,
+  radius/spacing scale) is enforced by the repo's design-lint tests/script in the
+  unit gate. **A design TC counts covered only when `/design-review` passes AND the
+  static lint is green — the two together are the gate** (the ERP field rule);
+  `/design-review` alone judges only what can't be grepped.
+- [ ] **Deviations are failures** — each `DESIGN.md`-or-shadcn mismatch is logged
+  against its TC-ID, not waved through.
+
+> **Required when**: any UI changes. These are `TC-<EPIC>.UI-<n>` (or fold into the
+> relevant `FUNC`/`A11Y` case) and are the **canonical UI-conformance criteria** the
+> rest of koni-qc + the koni-harness Review stage point at. koni-qc does not eyeball
+> pixels itself — it **delegates to gstack `/design-review`**; `DESIGN.md` + the shadcn
+> standard are the source of truth. (A repo not built on shadcn substitutes its own
+> declared component system in the shadcn slot; Koniverse UI repos default to shadcn.)
+
+---
+
+## Internationalization
+
+- [ ] **Locale** — number / date / currency formatting per locale.
+- [ ] **RTL** — layout mirrors for right-to-left scripts.
+- [ ] **Encoding** — UTF-8 / emoji / multi-byte input round-trips intact.
+- [ ] **Timezone** — display + storage correct across DST and offset boundaries.
+
+> **Required when**: the product ships in >1 locale, or stores user-entered text /
+> timestamps. (Native-language step text stays internal per RULE-13.)
+
+---
+
+## Reliability & resilience
+
+Failure-mode tests — prove graceful degradation, not just the happy path.
+
+- [ ] **Offline** — action while disconnected surfaces a clear state, no data loss.
+- [ ] **Timeout** — slow dependency hits timeout → handled, not hung.
+- [ ] **Retry / idempotency** — retried request does not double-apply.
+- [ ] **Partial failure** — one leg of a multi-step op fails → consistent rollback or compensation.
+
+> **Required when**: the feature spans a network call, multi-step transaction, or
+> external dependency.
+
+---
+
+## Compatibility
+
+A cross-platform / cross-browser matrix, not a single environment.
+
+- [ ] **Browsers** — Chromium / Firefox / Safari (+ last-2-versions) per supported set.
+- [ ] **Platforms** — `[extension]` / `[mobile]` / `[webapp]` / `[telegram]` variants run.
+- [ ] **Viewport** — responsive breakpoints; touch vs pointer.
+
+> **Required when**: the feature renders UI or runs across >1 surface. Use the
+> platform-variant columns from [`traceability.md`](traceability.md).
+
+---
+
+## Observability
+
+Assert that the system tells you what happened.
+
+- [ ] **Logs** — key events logged at the right level; no secret leakage.
+- [ ] **Metrics** — counters / latency emitted for the critical path.
+- [ ] **Traces** — a request is traceable end-to-end across service boundaries.
+
+> **Required when**: a service boundary, a money/asset path, or anything an
+> on-call engineer must debug in production.

--- a/.claude/skills/koni-qc/references/qc-workflow.md
+++ b/.claude/skills/koni-qc/references/qc-workflow.md
@@ -1,0 +1,250 @@
+# qc-workflow — the QC lifecycle (frame → design → review → execute → release gate)
+
+> **Load when**: you are running QC end-to-end for an epic or release. This is the
+> spine that sequences the other references and the delegated skills. koni-qc owns
+> the **methodology**; every concrete action below **invokes** a delegate
+> (koni-docs / gstack / koni-harness / BMAD) and never reproduces it.
+
+The five stages are gated: a stage's exit is the next stage's entry. The matrix
+from [`traceability.md`](traceability.md) is the artifact that flows through all of them.
+
+---
+
+**Contents**: [1. Frame](#1-frame) · [2. Design](#2-design) ·
+[3. Self-review](#3-self-review) · [3b. Generate](#3b-generate--spec--runnable-tests) ·
+[4. Execute](#4-execute) · [5. Release gate](#5-release-gate) ·
+[Entry / exit criteria](#entry--exit-criteria) ·
+[Test-data & fixtures strategy](#test-data--fixtures-strategy) ·
+[Test lifecycle](#test-lifecycle)
+
+---
+
+## 1. Frame
+
+Decide *what* is under test and *when* it is done.
+
+- **Pick the user story (the unit)** — invoke **koni-harness `sprint.sh`** to select
+  the target **US** (do not hand-pick). The **US is the unit of coverage and
+  planning, not the epic** (see [`test-organization.md`](test-organization.md) §0);
+  the epic is just the file container. For a backlog, build a **per-US, risk-tiered
+  coverage plan** (every shipped `done` story with no covering TC, ordered
+  Tier 1 security/money/external → Tier 2 core/perf → Tier 3 UI) and attack in
+  that order — not "epic by epic". **For a whole repo** (not one epic), first stand
+  up the QA-tracking epic + strategy + Definition-of-Done via
+  [`whole-project-qc.md`](whole-project-qc.md) — this per-epic lifecycle then runs
+  inside it, and QC is not "done" on specs alone (that file's §5 done-bar).
+- **Read the system-design docs IN DETAIL — BEFORE any test design (MANDATORY).**
+  Invoke **koni-docs** to read the PRD FRs, the **story + its AC**, ARCHITECTURE,
+  `DESIGN.md`, and every per-US design artifact (technical design, UI/UX spec) —
+  **in full, not skimmed**. These are the source of truth; AC are the units the
+  matrix traces, and each TC will `maps_to` this US.
+- **Secure the two enumeration inputs (author them from code if absent).** 10× density
+  cannot be conjured from a 17-line AC list — the exemplar's 154 rows are *mechanically
+  derived* from richer per-US docs. Before Design, the US must have:
+  1. a **technical-design contract** — routes/RPCs/RLS policies + request/response
+     schemas + an **error-code table** (feeds the endpoint/status/error enumerations);
+  2. a **UI-state inventory** — components × states (loading/disabled/empty/error/
+     toast/focus) (feeds the functional enumerations).
+  If either doesn't exist as a doc, **derive and write it from the code first** (a
+  stub in `docs/design/` or the story), then design tests from it. Skipping this is
+  how density silently defaults to the AC list. **Scope the inputs to the surfaces the
+  US actually has** — a US with no UI owes no UI-state inventory, a US with no API/RPC
+  surface owes no endpoint contract; only the inputs for surfaces that exist are
+  mandatory.
+- **Derive ACs if none are written** — the whole method is AC-anchored, so if the
+  story has FRs but no story-level acceptance criteria, derive them first: turn
+  each FR / user-facing behaviour into one testable, observable AC (a *Given →
+  When → Then* the matrix can trace). Prefer invoking **BMAD** to author the
+  missing ACs back into the story; never invent untracked ACs that live only in
+  the test doc. If an FR is too vague to yield an AC, raise it as a PRD/story gap.
+- **Run the change sweep (MANDATORY on any repo with a prior QC round)** — read the
+  CHANGELOG **and** `git log` since the last round, verify every feat has covering
+  TCs and every fix has a `REG` TC, and update the change-coverage ledger —
+  [`regression-learning.md`](regression-learning.md) §change-sweep. A fix with no
+  REG TC is a confirmed miss and enters the miss post-mortem before new authoring
+  starts (the miss tells you where the derivation is blind).
+- **Define scope** — in / out of scope; which surfaces; regression blast radius.
+- **Define entry / exit** — the criteria below; written before any case is authored.
+- **Define environment** — target build, data, accounts, feature flags.
+
+**Exit**: target US chosen (or a per-US tiered backlog), **design docs read in full +
+the two enumeration inputs present** (TD contract + UI-state inventory), **change
+sweep done + ledger updated** (when a prior round exists), scope + entry/exit +
+environment written. **Design may not start without them.**
+
+---
+
+## 2. Design
+
+Author the cases into the koni-docs container — fill its template, never copy it.
+
+- **Container** — author into **`docs/tests/test-cases/EPIC-N/`** (koni-docs
+  templates; [`test-organization.md`](test-organization.md) §1): the epic frame +
+  AC↔TC matrix into `index.md`, the TC rows into that story's `US-x.y.md` — never
+  rows into the index, never scope into a US file. (Legacy single `EPIC-NN.md`
+  repos: keep the file until the next epic-wide pass.)
+- **Derive cases** — for each AC, apply [`test-design.md`](test-design.md)
+  (partitioning, BVA, decision tables, state, pairwise) to enumerate
+  positive + negative + boundary; apply [`edge-coverage.md`](edge-coverage.md) so
+  coverage stops at thorough, not happy-path; apply [`nfr.md`](nfr.md) for the
+  security / perf / a11y / etc. rows that the trigger requires.
+- **UI ACs get a mandatory design-review case** — for any UI-bearing AC, add the
+  `TC-<EPIC>.UI-<n>` conformance case (`test-design.md` step 8): it must **pass gstack
+  `/design-review` against `DESIGN.md` AND the shadcn standard** ([`nfr.md`](nfr.md) §UI).
+  The Design stage is not complete for a UI AC until this case exists.
+- **Fill the canonical table** — every case is one rich-TC row per
+  [`traceability.md`](traceability.md) (TC-ID · priority · test-data · preconditions ·
+  action · expected · perf · side-effects · covered-by).
+- **Shape the suite by layer** — a US with an API surface and/or UI splits into the
+  API + functional suites of [`layered-suites.md`](layered-suites.md): by-endpoint
+  tables, category-prefixed functional cases, the orthogonal coverage matrices
+  (endpoint/status-code/error-code · pages/components/a11y), the named test-data
+  registry, and an `## Open Questions` section for every spec ambiguity found.
+- **Build the AC↔TC matrix** — the mandatory artifact, per
+  [`traceability.md`](traceability.md): every AC → ≥1 positive AND ≥1 negative AND
+  ≥1 **boundary-or-edge** TC (a `BND` *or* `EDGE` case fills the third slot),
+  each a distinct case (no double-counting).
+
+**Exit**: every AC mapped; the canonical table + the AC↔TC matrix are complete.
+
+---
+
+## 3. Self-review
+
+Grade the suite before anyone executes it.
+
+- **Grade against [`quality-bar.md`](quality-bar.md)** — all of Band A **and Band D
+  (density/exhaustiveness)**; demonstrably exceed Band B and Band C.
+- **No orphans** — no AC without a TC; no TC without an AC (per the completeness
+  rule in [`traceability.md`](traceability.md)).
+- **Coverage classes present** — edge taxonomy applied; required NFR sections filled.
+- **Density sanity check (warn, not a gate)** — the 3-slot matrix is a floor; a US
+  with an API surface and/or UI that lands **under ~30 atomic cases** is presumed
+  **under-derived** until justified: re-run [`test-design.md`](test-design.md) step 9
+  (cross-multiply shared classes × surfaces — the exemplar density is ~150/US) and
+  either derive the missing products or record *why* this US is genuinely small in
+  `## Open Questions`. A green matrix with an unmultiplied surface still fails this
+  check.
+
+**Exit**: Band A fully cleared; **Band D cleared or explicitly justified**; zero
+orphans. Fail → return to **Design**.
+
+---
+
+## 3b. Generate — spec → runnable tests
+
+A graded spec is not automated until each TC is a **runnable test**. This is the
+step that was missing when the loop stalled at "specs written, `— (manual)`,
+`test-reports/` empty".
+
+- **Generate a test per TC**, named starting with its TC-ID, into
+  `<app>/tests/epic/EPIC-NN/…` — the full contract is
+  [`test-automation.md`](test-automation.md) §1 (it also materialises the
+  `tests/epic/` tree, which the doc scaffold does not create).
+- **Write the `Covered-by` handle back** into each spec row (flip `— (manual)`).
+- Per-function **unit** tests remain Dev-authored ([`unit-coverage.md`](unit-coverage.md));
+  the AC↔TC **integration/e2e/smoke** tests are generated here.
+
+**Exit**: every Critical/High TC has a runnable, TC-ID-named test; no spec row
+left `— (manual)` for an automatable case.
+
+---
+
+## 4. Execute
+
+Run the generated tests and instrument the results — **koni-qc drives + gates;
+the repo's runner executes** (koni-qc never runs tests itself).
+
+- **Code tests (unit / integration / e2e / smoke)** — run with the repo runner and
+  the **reporter contract** ([`test-automation.md`](test-automation.md) §2): run →
+  parse the TC-ID from each test name → write `test-reports/YYYY-MM-DD/EPIC-N/report.md` (+ `auto-coverage.md`, `summary/`)
+  → **write back Status + coverage % + link to the story** (§3 sync). This is the
+  automation, not a hand-fill.
+- **UI-bearing cases** — additionally drive gstack `/design-review` against the repo's
+  `DESIGN.md` **and the shadcn standard** ([`nfr.md`](nfr.md) §UI); a UI case isn't done
+  until it passes **both** (record any `DESIGN.md`-or-shadcn deviation as a failure with
+  the TC-ID). gstack `qa` / `qa-only` / `investigate` / `browse` remain the tools for
+  interactive/browser flows a headless runner can't cover.
+- **Instrumentation** — coverage % **per US** and by type, pass / fail / blocked, and
+  perf vs SLA ([`nfr.md`](nfr.md)) — emitted by the reporter, not typed by hand.
+- **The report meets the content bar** — honest actuals, skipped/blocked with
+  reason + action, failed-by-category root cause, perf stats, evidence links
+  ([`report-quality.md`](report-quality.md)); a bare pass/fail tally does not exit
+  this stage.
+- **Scaling a whole-repo conversion: fan out per epic/domain with a repoint
+  contract.** The pattern that took ERP 9.3%→100% in ~34h: spawn **one agent per
+  epic/domain** (koni-harness [`parallel-orchestration.md`](../../koni-harness/references/parallel-orchestration.md)
+  Tier B), each authoring real tests against the live stack
+  ([`live-harness.md`](live-harness.md)) + self-verifying, returning a **JSON repoint
+  contract** — `{tcId → handle, deferred[], prodBugs[]}` — while the **orchestrator
+  alone** re-points the specs centrally, re-runs the full suites under the
+  broken-handle enforcer, fixes surfaced bugs through the gate, and commits per
+  round. Workers never edit specs directly (single-writer, no repoint races).
+
+**Exit**: every Critical/High case executed via the runner/reporter (or `/design-review`
+for UI); `report.md` written; stories synced.
+
+---
+
+## 5. Release gate
+
+Turn results into a ship decision.
+
+- **Check entry / exit** — exit criteria met (below). If not, the gate fails.
+- **A CI test gate exists** — the suite + coverage threshold run on every push/PR
+  (bootstrap it if absent: [`test-automation.md`](test-automation.md) §4). Without it
+  the suite silently rots — the #1 finding of the koni-erp-02 audit.
+- **Release report** — invoke **koni-docs** to produce the release report + ship
+  decision from the run.
+- **Commit / gate** — invoke **koni-harness `gate`** to commit and gate the release.
+
+- **Close the learning loop** — every bug this cycle surfaced (failed TC, bug-bash,
+  prod escape during the round) has its three things (REG TC + class finding +
+  generalization sweep) per [`regression-learning.md`](regression-learning.md);
+  the change-coverage ledger has this round's row. A release gate that ships bugs
+  forward without REG cases re-arms them.
+
+**Exit**: exit criteria met, release report produced, learning loop closed
+(REG cases + ledger row), koni-harness gate green.
+
+---
+
+## Entry / exit criteria
+
+| | Entry | Exit |
+|---|---|---|
+| **Inputs** | PRD/stories/AC/ARCH read; env ready | — |
+| **Coverage** | scope agreed | AC↔TC matrix complete, no orphans |
+| **Generation** | spec graded | every Critical/High TC has a runnable TC-ID-named test; no automatable case left `— (manual)` |
+| **Execution** | suite generated | all Critical/High run via runner/reporter; `report.md` written; stories synced; 0 Critical failures open |
+| **CI gate** | runner + coverage script exist | the repo's CI runs the suite + coverage threshold on every push/PR/build (Actions, or the container build gate — `test-automation.md` §4) |
+| **NFR** | required triggers identified | required NFR sections executed |
+| **Perf** | SLA budgets set | p95 within budget or waiver logged |
+| **Decision** | — | release report + ship decision recorded |
+
+---
+
+## Test-data & fixtures strategy
+
+Decide once, in **Frame**; the backup had none.
+
+- **Concrete + reusable** — every TC carries a real value (no "valid input").
+- **Fixtures** — seed data, accounts, and tokens defined as named, re-creatable
+  fixtures; teardown restores state.
+- **Isolation** — each run starts from a known state; no cross-run contamination.
+- **Sensitive data** — secrets injected from env, never committed.
+
+---
+
+## Test lifecycle
+
+Every case has a state; the suite is curated, not append-only.
+
+- **active** — in the current suite; runs each relevant cycle.
+- **deprecated** — superseded or feature removed; keep the TC-ID (never renumber),
+  mark deprecated, stop running.
+- **archived** — moved out of the active file but retained for history; referenced
+  by ID in reports / lessons.
+
+`RC-` regression cases ([`traceability.md`](traceability.md)) stay **active** every
+release by definition — they are the regression scope.

--- a/.claude/skills/koni-qc/references/quality-bar.md
+++ b/.claude/skills/koni-qc/references/quality-bar.md
@@ -1,0 +1,122 @@
+# quality-bar — the scored rubric ("better than both corpora")
+
+> **Load when**: the **Self-review** stage of [`qc-workflow.md`](qc-workflow.md),
+> and again in author-blind review. This is the bar koni-qc must clear: it must
+> **beat** the weak manual backup, **match** the Koni-Finance production standard,
+> and **close** Koni-Finance's residual gaps. Grade a suite against all three bands.
+
+Score each item as a checkbox. The **Pass rule** at the bottom is the gate.
+
+**Contents**: [Band A — beat the manual backup](#band-a--beat-the-manual-backup-must-clear-all) ·
+[Band B — match the Koni-Finance standard](#band-b--match-the-koni-finance-standard) ·
+[Band C — close its residual gaps](#band-c--close-its-residual-gaps) ·
+[Pass rule](#pass-rule)
+
+---
+
+## Band A — beat the manual backup (must clear ALL)
+
+The 12 gaps of the backup corpus, each closed. Every box must be ticked.
+
+- [ ] **Explicit TC IDs** — every case has a stable `TC-<EPIC>.<TYPE>-<n>` ([`traceability.md`](traceability.md)).
+- [ ] **AC↔TC matrix** — present and complete; the mandatory artifact. (Complete = the
+  **floor** — case *volume* is judged by the density sanity in
+  [`qc-workflow.md`](qc-workflow.md) §3, not by this box.)
+- [ ] **≥50% off-path** — not ~70% happy-path; at least half the cases are **off-path = negative (NEG) + boundary (BND) + edge (EDGE)** (the three off-path TYPEs in [`traceability.md`](traceability.md)). NFR types (SEC/PERF/A11Y/UI) and happy-path types (FUNC/SMK/E2E/API) do **not** count toward the 50%.
+- [ ] **NFR present** — required [`nfr.md`](nfr.md) sections filled, not <5%.
+- [ ] **UI-conformance case authored (if UI-bearing)** — every UI-bearing AC has a
+  `TC-<EPIC>.UI-<n>` (or a folded `FUNC`/`A11Y`) whose pass condition is `/design-review`
+  vs **DESIGN.md + the shadcn standard** ([`nfr.md`](nfr.md) §UI). Authoring item (the case
+  exists); its *execution* (actually passing `/design-review`) is deferrable like the other
+  execution items. `N/A` only if the suite has no UI surface.
+- [ ] **Coverage % reported** — the *execution* coverage report: % **per US** (the unit — done stories with ≥1 covering TC ÷ done stories; see `test-organization.md` §0) and by AC/type, from a run (distinct from the authoring AC↔TC matrix above; this is an execution item, deferrable on an unrun suite — see the Author-mode carve-out).
+- [ ] **Test-data strategy** — concrete, reusable values + named fixtures.
+- [ ] **Entry / exit criteria** — written before authoring; checked at the gate.
+- [ ] **Test lifecycle** — active / deprecated / archived states applied.
+- [ ] **Risk-based order** — Critical/High/Medium/Low priority set by impact × likelihood.
+- [ ] **Regression scope** — `RC-` set defined as the per-release regression scope.
+- [ ] **Automation linkage** — `Covered-by` filled with one of the five fixed forms
+  (`*.spec.ts::name` · `PROPOSED:<path>::name` · `— (manual)` · `OPS-DEPLOY:<runbook>` ·
+  `DESIGN-REVIEW:<ref>`); `PROPOSED:` counts as filled-but-uncovered
+  (see [`traceability.md`](traceability.md)).
+- [ ] **Real execution reports** — koni-docs `test-report.md` filled, not empty, and
+  meeting the [`report-quality.md`](report-quality.md) content bar.
+
+---
+
+## Band B — match the Koni-Finance standard
+
+The production strengths to codify. Must demonstrably match.
+
+- [ ] **Rich per-TC metadata** — the full canonical table (test-data · preconditions · action · expected · actual · status · perf · side-effects · covered-by).
+- [ ] **Dedicated security suite** — SEC cases present; standalone `<feature>-security-test-cases.md` when ≥5.
+- [ ] **Concrete reusable test data** — every TC carries a real, re-runnable value.
+- [ ] **Execution instrumentation** — coverage % by AC/type, pass/fail/blocked, perf vs
+  SLA. A bare `Pass` is the floor, not the target: an exemplar row carries the
+  **captured actual response/behaviour + the timing** (the reporter already extracts
+  `durationMs` + failure detail — surface them, don't drop them).
+
+---
+
+## Band C — close its residual gaps
+
+What Koni-Finance lacked; koni-qc must exceed here.
+
+- [ ] **Full AC↔TC matrix** — every AC mapped, no orphans (Koni-Finance had rich TCs but no matrix).
+- [ ] **Env / fixtures playbook** — environment + fixtures defined and re-creatable.
+- [ ] **A11y / i18n** — accessibility and internationalization sections covered when triggered.
+- [ ] **Perf SLA** — explicit latency / throughput budgets asserted, not just measured.
+- [ ] **Cadence** — when the suite (smoke / regression / full) runs is defined.
+
+---
+
+## Band D — density & exhaustiveness (the gate that stops the 10× gap recurring)
+
+A suite can clear Bands A–C at ~3 cases/AC and still be **1/10 of real density** (the
+ERP field finding: 100% of 431 enumerated cases resolved, while the exemplar carries
+154 cases for ONE US — resolution and enumeration are orthogonal axes). Band D gates
+the enumeration axis:
+
+- [ ] **Cross-multiplication done** — [`test-design.md`](test-design.md) **step 9** ran:
+  every shared class × every surface (the class and surface lists live in step 9, not here).
+- [ ] **Matrix completeness = 100%** — every cell of the applicable
+  [`layered-suites.md`](layered-suites.md) matrices (incl. field × validation and
+  state-transition) is a TC-ID or an **explicit N/A** — never blank.
+- [ ] **Full BVA per bounded field** — the step-9 discrete BVA rows present in the
+  field × validation matrix (not one collapsed "edge" row).
+- [ ] **Full error-code + status coverage** — every status/error an action can return
+  has a TC.
+- [ ] **One row per scenario** — no spec-level bundling (a test may assert N scenarios;
+  the spec then carries N TC-IDs — [`traceability.md`](traceability.md)).
+- [ ] **Density plausible** — cases/US in the neighborhood the surfaces imply
+  (typically **40–150 for an API+UI US**; the ~30-case Self-review warn of
+  [`qc-workflow.md`](qc-workflow.md) §3 cleared or explicitly justified).
+
+---
+
+## Pass rule
+
+> **A suite passes only if it clears every item of Band A, every item of Band D, and
+> demonstrably exceeds Band B and Band C.** Any unticked Band-A box is a hard fail —
+> return to **Design**. **A suite that clears Band A but fails Band D is *thin*** —
+> also return to Design and expand (100%-resolution must never masquerade as
+> 100%-enumeration). A Band-B/C item that is merely matched, not exceeded, is a
+> finding to raise in review.
+
+**Author-mode vs Execute-mode bar.** Two Band-A items — **Real execution reports**
+and **Coverage % reported** — depend on the suite having been *run*. An
+**authoring** artifact (test cases written, not yet executed: every row `Not
+Executed`) legitimately marks those two `N/A — deferred to Execute` rather than
+failing them; it must clear every *other* Band-A item. The full Band-A bar
+(including the two execution items) applies at the **Execute/Release** stage, once
+the koni-docs `test-report.md` is filled. Do not tick an execution item on an
+unrun suite — mark it deferred.
+
+**The depth bar (applies to every koni-qc artifact).** *Creating a file is not
+authoring it.* A `test-cases/EPIC-N/` spec with an empty matrix, an audit with
+bullet-only findings, a one-sentence `STRATEGY.md`, or a stub story (title + a Goal
+line + a few bullets) **fails the bar regardless of the bands** — it looks tracked
+but carries no decision value. Ground each artifact in real files/commits, don't
+fill a template with generic sentences, and **spot-check 3 random outputs** before
+declaring a batch done. Full rule (incl. story-depth sections + the whole-project
+Definition-of-Done): [`whole-project-qc.md`](whole-project-qc.md) §6.

--- a/.claude/skills/koni-qc/references/regression-learning.md
+++ b/.claude/skills/koni-qc/references/regression-learning.md
@@ -1,0 +1,120 @@
+# regression-learning — the QC harness loop (learn from real bugs, sweep real changes)
+
+> **Load when**: a real bug escaped to prod/staging, a hotfix landed, a bug-bash
+> wrapped, a run failed in a *new* way — or a QC round starts and you need to know
+> what shipped since the last one ("did we miss cases?", "turn this bug into tests",
+> "make the suite learn"). koni-qc is not a one-shot author: it runs as a **harness**
+> — every cycle observes real-world signals, converts them into cases, and leaves the
+> suite strictly stronger. This file owns that loop; the derivation machinery it
+> reuses lives in [`test-design.md`](test-design.md) step 9.
+
+**Contents**: [The loop](#the-loop-observe--capture--derive--generate--enforce) ·
+[Every escaped bug becomes three things](#every-escaped-bug-becomes-three-things-the-learning-rule) ·
+[The miss post-mortem](#the-miss-post-mortem-why-did-no-tc-catch-it) ·
+[The change sweep](#the-change-sweep-changelog--git-log--mandatory-every-qc-round) ·
+[Bug-bash intake](#bug-bash--suite-end-of-sprint) · [Ownership](#ownership)
+
+---
+
+## The loop (Observe → Capture → Derive → Generate → Enforce)
+
+The coverage counterpart of koni-harness's execute loop:
+
+1. **Observe** — the real-world signals: escaped bugs / prod incidents, `fix:`
+   commits and hotfixes, bug-bash findings, broken handles and orphan IDs from the
+   reporter ([`test-automation.md`](test-automation.md) §2), `/design-review`
+   failures, newly-flaky tests, support tickets.
+2. **Capture** — a `findings.md` entry (`F-n`): one-sentence root cause + the
+   **class** it belongs to (an enumeration class, not a story name) + the layer that
+   *should* have caught it.
+3. **Derive** — the REG case + the generalization sweep (next section).
+4. **Generate** — runnable tests per [`test-automation.md`](test-automation.md) §1;
+   **test-first while the bug is still open** (the REG test is red against the bug,
+   green after the fix — proof it actually reproduces it).
+5. **Enforce** — REG cases join the **permanent regression scope** (`RC-` set,
+   active every release by definition — [`qc-workflow.md`](qc-workflow.md)
+   §Test lifecycle); broken = 0 stays the bar.
+
+One cycle per signal batch; the loop has no terminal state — that is the point.
+
+## Every escaped bug becomes THREE things (the learning rule)
+
+1. **A `REG` TC that reproduces it** — `TC-<EPIC>.REG-<n>`, written red against the
+   open bug, flipped green by the fix. **Never close a bug without its REG case** — a
+   fix without a regression test is a fix that can silently unfix. When the fix
+   already shipped (a change-sweep retro-fit), the reproduction proof is:
+   **revert the fix locally (checkout the pre-fix commit or stash the patch) — the
+   REG test must go RED there**; record that red run in the finding. Relabeling an
+   adjacent passing test as REG proves nothing and fails this rule.
+2. **A `findings.md` root-cause entry naming the class** — not "US-3.2 sync bug" but
+   "unvalidated concurrent state transition". The class name is what makes step 3
+   mechanical.
+3. **A generalization sweep** — the bug is *evidence its whole class is
+   under-enumerated*: re-run [`test-design.md`](test-design.md) step 9 for **that
+   class × every sibling surface**. One cross-tenant leak on `sources` ⇒ re-probe
+   every table's RLS; one `NaN` in a KR calculator ⇒ BVA every numeric aggregator;
+   one unescaped name field ⇒ injection-probe every free-text input. The sweep emits
+   ordinary TCs (`SEC`/`NEG`/`BND`/…) — `REG` marks only the reproduced instance.
+
+## The miss post-mortem (why did no TC catch it?)
+
+For every escaped bug, record which of the four failure modes let it through
+(in the `findings.md` entry):
+
+| Mode | It escaped because… | The fix targets |
+|---|---|---|
+| **Enumeration gap** | the class was never derived at all | the *derivation*: add the class to step 9's list for this suite; if the class is generic (not repo-specific), raise it as a koni-qc skill lesson so every future suite gets it |
+| **Density gap** | class derived, this surface never multiplied | the generalization sweep above |
+| **Wrong layer** | a case existed but as manual/e2e when a unit/integration probe would have run per-commit | re-layer the case ([`layered-suites.md`](layered-suites.md)) |
+| **Execution gap** | the case existed and was automated but did not run where it mattered (broken handle, env-pending in the lane that shipped, CI hole) | the lane/CI wiring ([`test-automation.md`](test-automation.md) §4) |
+
+The post-mortem targets the **class, never just the instance** — one bug fixed plus
+one TC added is the floor, not the finish.
+
+## The change sweep (CHANGELOG + git log — MANDATORY every QC round)
+
+A suite silently rots when shipped changes outrun it. At the **start of every QC
+round** (the Frame stage, [`qc-workflow.md`](qc-workflow.md) §1) — and at any
+koni-harness doc-gate on a covered repo:
+
+1. **Window** = last QC round → `HEAD` (the newest `test-reports/YYYY-MM-DD/` date;
+   on a legacy epic-first repo, the newest `EPIC-*/MMDDYYYY/` run date; else the last
+   change-ledger row below; none of the three → this is the first round, sweep from
+   the coverage plan's baseline instead).
+2. **Read BOTH** the CHANGELOG entries in the window **and**
+   `git log --oneline <since>..HEAD`. The changelog says what was *declared*; the
+   log says what actually *changed* — **diff them**: an undeclared change is itself
+   a finding.
+3. **Every feat/change entry** → does the touched US/surface have TCs covering the
+   *new* behaviour? Missing → derive it (through the normal Design inputs,
+   qc-workflow §1 — not ad-hoc).
+4. **Every fix entry** → does a `REG` TC exist reproducing what it fixed? **A fix
+   with no REG TC is a confirmed miss** (the bug itself proved the suite was blind
+   there) → run the miss post-mortem, then apply the three-things rule
+   retroactively.
+5. **Record in the change-coverage ledger** — a standing table in `findings.md`:
+   `window · commit/entry · US · verdict (covered / TC-added / miss → post-mortem) ·
+   TC-IDs`. The ledger row is what makes the *next* window computable.
+
+Never skip the sweep because the window is long: cap it at the top-20 riskiest
+changes (Tier-1 first, per [`test-organization.md`](test-organization.md) §0) and
+record the cut honestly in the ledger — a silently-truncated sweep reads as "swept
+everything" when it didn't.
+
+## Bug-bash → suite (end of sprint)
+
+`bug-bash/sprint-YYYY-WNN.md` findings run the same pipeline: every **confirmed**
+finding gets the three things; unconfirmed observations land in `findings.md` as
+open questions with an owner. A bug-bash whose findings never became TCs was a
+social event, not QC.
+
+## Ownership
+
+koni-qc owns the **loop + the ledger format**; `findings.md` / `bug-bash/` live in
+the repo ([`test-organization.md`](test-organization.md) §1); **koni-harness** owns
+lesson capture at its commit gate — a harness lesson that is a *coverage* lesson
+lands here as a class entry, and this loop's step-9 class additions flow back as
+skill lessons when generic; the **reporter** ([`test-automation.md`](test-automation.md)
+§2) supplies the broken/orphan/env-pending signals the loop observes. gstack /
+BMAD are delegates for reproduction and story updates, never replacements for the
+REG case.

--- a/.claude/skills/koni-qc/references/report-quality.md
+++ b/.claude/skills/koni-qc/references/report-quality.md
@@ -1,0 +1,107 @@
+# report-quality — the execution-report content bar
+
+> **Load when**: producing or grading a test **execution report** (auto `report.md` or
+> manual `report-manual.md`). The reporter contract ([`test-automation.md`](test-automation.md)
+> §2) defines the *mechanics* (path, status fold, write-back); koni-docs
+> `templates/test-report.md` owns the *container*; **this file owns what a report must
+> CONTAIN to be decision-grade** — the bar the US-001.001 exemplar reports set. A report
+> that only lists pass/fail rows is a tally, not a report: it can't answer "what do we do
+> next?".
+
+**Contents**: [Honest actuals](#honest-actuals-the-one-rule-above-others) ·
+[Required sections](#required-sections) · [Evidence rule](#evidence-rule) ·
+[Applies to auto + manual](#applies-to-auto--manual) · [Ownership](#ownership)
+
+---
+
+## Honest actuals (the one rule above others)
+
+**`Actual` is the real observed output — never a paraphrase, never a copy of Expected.**
+A passing API case shows the actual response body (truncated sensibly); a failing UI case
+shows the actual failure text verbatim (`Test timeout of 30000ms exceeded`,
+`expect(locator).toBeVisible() failed — element(s) not found`). Copy-of-expected actuals
+are how a suite reads green while proving nothing — treat one as a review finding. This
+is what makes a failure diagnosable from the report alone.
+
+## Required sections
+
+An execution report is decision-grade when it carries all of these (N/A allowed only
+where the class genuinely doesn't apply):
+
+1. **Execution overview — with the denominator named** — totals with percentages: total
+   · executed · passed · failed · skipped · blocked · not-executed, plus date /
+   environment / runner / build under test. Percentages, not just counts — and **any
+   "100%" must name its denominator and what the number does NOT measure in the same
+   sentence** ("100% of 431 *enumerated* cases resolved — this measures resolution, not
+   enumeration density"). The ERP field lesson: an operator drove 431/431 = 100% and
+   presented it as completeness while the suite was 1/10 of reference density —
+   resolution and enumeration are orthogonal axes and the report must say which one a
+   number is on.
+2. **Results by group** — one row per endpoint / page / suite group with its own
+   pass-rate, so the weak area is visible (not one global number).
+3. **Skipped + blocked, each with Reason AND Action Required** — every non-executed case
+   is a row: *why* it didn't run and *what unblocks it*. A bare "Skipped" hides scope
+   silently. The two words are distinct states with distinct sources: **blocked** = a
+   precondition/dependency was unmet at run time (the reporter's fold emits it —
+   [`test-automation.md`](test-automation.md) §2; "needs Docker", "needs wallet
+   extension"); **skipped** = a *deliberate scope-out for this round*, recorded by the QC
+   driver in the notes/manual report, never emitted by the reporter ("deferred to
+   integration testing"). Feature-unbuilt cases are `impl-gap` (spec flag), not either.
+4. **Failed-by-category with root cause** — group the failures by their real cause
+   ("frontend page not implemented" ≠ "regression in implemented flow"); the two demand
+   different next actions and must not be summed into one failure count.
+5. **Contract-coverage verification** (API runs) — the status-code + error-code matrices
+   from [`layered-suites.md`](layered-suites.md), re-checked against what the run
+   actually exercised.
+6. **Perf statistics** — response-time min / max / avg per group (the canonical table's
+   `Perf` column aggregated), vs SLA where one exists ([`nfr.md`](nfr.md)).
+7. **Implementation-status table** (when failures trace to unbuilt surface) — page/
+   component → Implemented / Partial / Not implemented → coverage % — turning a wall of
+   red into an honest "the suite is ahead of the build" statement.
+8. **Recommendations / next steps** — numbered, specific, actionable ("implement
+   `/onboarding/workspace` — unblocks 6 TCs"), not "fix the failures".
+9. **Command reference** — the exact commands to reproduce the run (env vars included),
+   so the next person reruns it without archaeology.
+10. **Density telemetry** — cases/US distribution (and cases/AC where computable), with
+   any US below the Self-review density warn flagged — so 100%-resolution can never
+   masquerade as 100%-enumeration again. The reference reporter
+   ([`test-automation.md`](test-automation.md) §2) emits this table.
+
+## Evidence rule
+
+Every **failure and blocker** links its artifacts: the runner spec `file:line`, and the
+video / screenshot / log path the run produced. Every **manual/visual verification**
+(UI conformance, bug-fix rounds) attaches the screenshot or GIF. A failure without
+evidence is a claim; with evidence it is replayable. (Store artifacts under the run
+folder — `test-reports/YYYY-MM-DD/EPIC-N/img/` for automated runs, `img-manual/` for
+manual ones, per [`test-organization.md`](test-organization.md).)
+
+## Applies to auto + manual
+
+- The **auto `report.md`** stays the **reporter's exclusive artifact** (its rows +
+  the rollups it computes — sections 1–4 and 6 from run data; section 5's
+  contract matrices additionally need the suite's status/error-code enumerations,
+  which the reconcile step already reads from the spec). Scope honestly: the shipped
+  reference ([`../scripts/qc-report.mjs`](../scripts/qc-report.mjs)) implements the
+  **parse + classify + enforce + density core** (§1's denominator line, the case rows
+  with timing + failure detail, broken/orphan lists, item 10's density table); the
+  per-group / failed-by-category / perf rollups here are **adapt-on-copy** — the repo's
+  copy adds them, they are not free.
+- **Driver-authored sections live in `report-notes.md`** — a named sibling in the
+  same run folder for sections the reporter cannot know (7 implementation status,
+  8 recommendations, 9 command reference, and any skipped-scope decisions). This
+  preserves the "reporter is the ONLY writer of `report.md`" invariant
+  ([`test-organization.md`](test-organization.md) §1) — the QC driver **never**
+  appends to or edits `report.md` itself.
+- The **manual `report-manual.md`** (browser QA, `/design-review` passes, bug-fix
+  rounds) carries the same bar in one file — an exemplar manual report reads exactly
+  like an exemplar auto one, plus its screenshots.
+
+## Ownership
+
+koni-qc owns this **content bar** (and `report-notes.md` is free-form under it — no
+koni-docs template needed); koni-docs owns the `report.md`/`report-manual.md`
+**template/container**;
+[`test-automation.md`](test-automation.md) owns the reporter **mechanics** (path
+validator, status fold, story write-back). [`quality-bar.md`](quality-bar.md)'s
+"Real execution reports" Band-A item is graded against this bar.

--- a/.claude/skills/koni-qc/references/skill-grading.md
+++ b/.claude/skills/koni-qc/references/skill-grading.md
@@ -1,0 +1,111 @@
+# skill-grading — QC for a *skill* artifact (not a product feature)
+
+> **Load when**: the thing under test is a **skill** (a `SKILL.md` + its
+> `references/` / `scripts/`), not a product feature. This is koni-qc's quality
+> bar applied to skills. The koni-harness loop loads it in the **Review** stage
+> whenever the deliverable being built is a skill.
+
+**Contents**: [Why a separate bar](#why-a-separate-bar) ·
+[The four dimensions](#the-four-dimensions) · [How to run each](#how-to-run-each-dimension) ·
+[The method (non-negotiable)](#the-method-non-negotiable) ·
+[Scorecard](#scorecard) · [Composes, never reproduces](#composes-never-reproduces)
+
+A skill is a *deliverable* like any other, so it gets QC'd — but its failure modes
+are not a product's. A skill can be correct prose yet **never trigger**, hold a
+rule on paper yet **fold under pressure**, or read well yet **contradict its own
+worked example**. `quality-bar.md` grades a feature's *test docs*; this grades the
+*skill itself*.
+
+## Why a separate bar
+
+The core discipline is the same as everywhere in koni-qc: **independent
+dimensions, an honest self-grade, and a hard numeric bar**. What changes is the
+target and the tools. Grade across **four dimensions, each scored /25 (total
+/100), each by a _separate_ agent** so the verdicts can't collude (no halo effect
+from one grader liking the skill).
+
+**The standard pass bar is ≥95/100 — non-negotiable for every skill in the
+catalog.** A skill that scores below 95 does **not** pass review: fix the findings
+and re-grade until it clears 95 (foundational / high-blast-radius skills may set a
+higher bar, never lower). This is the Koniverse catalog standard, enforced by the
+koni-harness Review stage (see [CONTEXT D19](../../../docs/CONTEXT.md)).
+
+**Re-grade the *whole* skill, not just the diff.** After **any** change to a
+skill that already passed — even a one-line edit — re-run **all four dimensions**
+and confirm it still clears 95. A change can lower a dimension elsewhere (a new
+reference drifts a rule; a description edit shifts triggering). Never infer
+"still ≥95" from a passing review of the change alone — that is exactly how a
+95-skill silently slips to ~91 (see [LESSONS §8](../../../docs/LESSONS.md)).
+
+## The four dimensions
+
+| # | Dimension (/25) | What it measures | Delegated tool |
+|---|---|---|---|
+| **D1** | Discoverability / triggering | Does the `description` fire on the queries it should and **stay silent on near-misses**? | **skill-creator** (description optimizer / trigger eval), or a blind-router subagent |
+| **D2** | Rule-robustness under pressure | Do the skill's **hard rules hold** when an agent is pushed (deadline, authority, sunk cost) to violate them? | **writing-skills** — its `testing-skills-with-subagents.md` (the RED/GREEN pressure-scenario method) |
+| **D3** | Content quality | Internal consistency, correctness, the worked example obeys the skill's **own** rules, no gaps a fresh agent would hit | **author-blind review** (`superpowers:code-reviewer` — an agent that did NOT write it) |
+| **D4** | Best-practices conformance | Concise; **triggers-only** description (no workflow/ownership summary in frontmatter); progressive disclosure; TOCs on long references; degrees-of-freedom; one worked example | **Anthropic best-practices** — the `anthropic-best-practices.md` that ships *inside* the `writing-skills` skill (load it via that skill; never vendor a copy) |
+
+## How to run each dimension
+
+- **D1 — triggering.** Write ~16–20 realistic queries: 8–10 **should-trigger**
+  (varied phrasings, some not naming the skill) + 8–10 tricky **should-NOT**
+  near-misses (share keywords but belong to an adjacent skill). A **blind router**
+  routes each query to one skill using *descriptions only*; score precision +
+  recall for the skill under test. Where the `claude` CLI is available,
+  `skill-creator`'s `scripts/run_loop.py` (and `improve_description.py`) automate
+  this and optimize the description. **→ /25** (heuristic, use judgment — there's no
+  validator): scale by precision × recall; a perfect route is 25, each missed
+  should-trigger or false-positive near-miss costs a few points.
+- **D2 — pressure.** Using `writing-skills`' `testing-skills-with-subagents.md`,
+  give a subagent (that has the skill) a scenario engineered to make it violate
+  each hard rule under pressure; the rule holds = GREEN. Optionally run a no-skill
+  baseline to confirm the rule is non-obvious (RED). **→ /25**: 25 × (rules that
+  held GREEN ÷ rules tested).
+- **D3 — author-blind content.** Dispatch `superpowers:code-reviewer` on the skill
+  directory; it verifies every load-bearing claim against the actual files and
+  ranks findings. **→ /25**: take the reviewer's own score; if it doesn't emit one,
+  map by severity as a guide (~8 per surviving Critical, ~4 per Important, ~1 per
+  Minor off 25, floored at 0). Pass requires **no Critical/Important
+  finding survives** regardless of the number.
+- **D4 — best-practices.** Grade against the `anthropic-best-practices.md` inside
+  the `writing-skills` skill (load it via that skill — don't vendor a copy).
+  Because this is the most subjective dimension, **run it ≥2× and average** to
+  cancel grader variance. **→ /25**: the averaged rubric score.
+
+## The method (non-negotiable)
+
+- **One agent per dimension.** Never let a single agent score all four — a grader
+  that likes the skill inflates every axis.
+- **Re-verify after every fix round.** A fix is new code → it needs a new test.
+  Skill quality *converges*; expect 2–3 rounds, and **expect each fix to surface
+  the next finding** (the worked example you add to lift D3 can contradict the
+  config; the carve-out you add to make a self-grade honest can collide a name).
+  See [LESSONS §8](../../../docs/LESSONS.md).
+- **Average the subjective axis** (D4) over ≥2 runs.
+- **Re-grade all four dimensions, not just the changed file** — after any edit to a
+  passing skill, re-run the whole grade (a change can drop a dimension elsewhere).
+- **Stop** when a full round yields only Suggestions (no Important/Critical) **and
+  the total is ≥95**. If the total is <95, it has not passed — keep fixing.
+
+## Scorecard
+
+Emit one table; total and **PASS only if ≥95**.
+
+| Dimension | Score /25 | Tool | Key findings |
+|---|---|---|---|
+| D1 Triggering | … | skill-creator / blind-router | … |
+| D2 Rule-robustness | … | writing-skills | … |
+| D3 Content (author-blind) | … | code-reviewer | … |
+| D4 Best-practices | … | anthropic rubric (×2 avg) | … |
+| **Total** | **…/100** | — | **PASS (≥95) / FAIL (<95)** |
+
+## Composes, never reproduces
+
+skill-grading contributes the **rubric + the multi-dimension method**; it
+**delegates** every actual eval to the tool that owns it — `skill-creator`
+(triggering), `writing-skills` (pressure-tests + the best-practices doc),
+`superpowers:code-reviewer` (author-blind content). This is the same boundary
+koni-qc keeps everywhere: it adds the *coverage intelligence*, it never re-implements
+the engines. It is the skill-artifact analog of [`quality-bar.md`](quality-bar.md)
+(which grades a feature's test docs) — same philosophy, different target.

--- a/.claude/skills/koni-qc/references/test-automation.md
+++ b/.claude/skills/koni-qc/references/test-automation.md
@@ -1,0 +1,252 @@
+# test-automation — the loop that makes authored specs run and self-update
+
+> **Load when**: you have authored `test-cases/EPIC-N/` specs (TC-IDs + AC↔TC
+> matrix) and now need to **automate** them end-to-end. The authoring refs
+> ([`traceability.md`](traceability.md), [`test-design.md`](test-design.md),
+> [`edge-coverage.md`](edge-coverage.md)) produce the specs; **this file is the
+> chain that turns a spec into a running, self-reporting, CI-gated suite.**
+> Without it koni-qc stops at "specs written, `— (manual)`, `test-reports/` empty".
+
+**Contents**: [The automation spine](#the-automation-spine) ·
+[1. Generate](#1-generate-spec--runnable-test) · [2. Report](#2-the-reporter-contract) ·
+[3. Sync](#3-story-write-back-code--story) · [4. CI gate](#4-ci-gate--runner-bootstrap) ·
+[Ownership](#ownership--why-a-contract-not-a-vendored-tool)
+
+## The automation spine
+
+Five steps; **1→2→3 is the unbroken spine** (generate → report → sync), tree-scaffold
+is a prerequisite of 1, CI makes it enforced:
+
+```
+authored spec (TC-IDs)               ← authoring refs (done)
+   │  §1 GENERATE
+   ▼
+tests/epic/EPIC-NN/<slug>.<cadence>.spec.ts   (test name STARTS with the TC-ID)
+   │  run with the repo runner (vitest / jest / pytest / playwright) → JSON
+   ▼  §2 REPORT (the reporter contract)
+docs/tests/test-reports/YYYY-MM-DD/EPIC-N/report.md   (reporter is the ONLY writer)
+   │  §3 SYNC (story write-back)
+   ▼
+docs/sprints/stories/US-*.md   ← Status + coverage% + report link updated
+   │  §4 CI GATE
+   ▼
+.github/workflows/*.yml   ← runs the suite + coverage threshold on every push/PR
+```
+
+> **Do NOT delegate this to "gstack `qa`".** gstack `qa` / `/design-review` is
+> interactive **browser** QA — it does not generate unit/integration tests, parse a
+> TC-ID → pass/fail, or write `report.md`. Those are the contracts below.
+
+## 1. Generate: spec → runnable test
+
+For each `TC-<EPIC>.<TYPE>-<n>` row in `test-cases/EPIC-N/US-x.y.md` (legacy single `EPIC-NN.md` accepted):
+
+- **Materialize the code tree** first (it is NOT created by the doc scaffold in
+  [`test-organization.md`](test-organization.md) §6): `mkdir -p <app>/tests/epic/EPIC-NN`.
+- **Emit one test whose name STARTS with the TC-ID** so the reporter (§2) can parse
+  it — `test('TC-2.SEC-1 — tampered ciphertext is rejected', …)`. File:
+  `<app>/tests/epic/EPIC-NN/<slug>.<cadence>.spec.ts`, where the **cadence-suffix is
+  how/when the case runs** (`.integration` per-commit · `.e2e` per-PR · `.smoke`
+  per-deploy) — **not** the TC-ID TYPE (suffix ≠ TYPE, per
+  [`test-organization.md`](test-organization.md) §2). This step generates the AC↔TC
+  spec tests only; it does **not** emit `.unit.test.ts` files (those are Dev-authored,
+  see the Ownership note below).
+- **Map the canonical columns → arrange/act/assert**: `Test data` + `Preconditions`
+  → arrange/fixtures; `Action/Request` → act; `Expected` → assert; `Side-effects` →
+  post-assert. Group cases by feature with `describe`.
+- **Write the `Covered-by` handle back** into the spec row: `<path>.spec.ts::<name>`
+  (per [`traceability.md`](traceability.md)); flip the row from `— (manual)`.
+
+**Ownership.** The **AC↔TC-spec tests** (integration/e2e/smoke authored from
+the `EPIC-N/` spec) are **koni-qc-driven generation** — the agent generates them under this
+step. The **per-function unit tests** ([`unit-coverage.md`](unit-coverage.md)) stay
+**Dev-authored** alongside the code. Two authorship models, one runner + reporter.
+
+## 2. The reporter contract
+
+Turns a run into `report.md` — deterministic, no hand-editing.
+
+- **Input**: the runner's machine output — `vitest run --reporter=json`,
+  `jest --json`, `pytest --json-report` (needs the `pytest-json-report` plugin
+  installed — it is **not** in pytest core), or `playwright test --reporter=json`.
+- **Parse rule (per test) — FROZEN as an exact regex, not prose**: the TC token is
+  `TC-[0-9A-Z]+\.[A-Z][A-Z0-9]*-\d+` — the TYPE slot is `[A-Z][A-Z0-9]*`, **digits allowed
+  after the first letter**. A `[A-Z]+` TYPE regex silently drops every `E2E` and `A11Y`
+  case (a real field bug — ERP lost 9 cases before catching it). Match the **first TC
+  token in the runner's full test name** — runners prefix `describe` titles, so a strict
+  leading anchor breaks on `fullName`; §1's naming rule (test title STARTS with the
+  TC-ID) is what keeps "first token" and "the case's own ID" the same thing. Extract →
+  `{tcId, result: passed|failed|skipped, durationMs, error?}`. A test whose
+  name has no TC-ID is an **orphan test**; a test whose TC-ID is **absent from the spec**
+  is an **orphan ID**, and one whose TC-ID exists in the spec but asserts a *different*
+  case is a **collision** (the ERP-02 F-12 bug) — flag all three, the spec is the sole
+  authority for TC-IDs (test-organization §3).
+- **Spec-scan rule — only real TC rows count**: when enumerating spec tables, a row counts
+  as a case **only if its first cell matches the frozen TC regex** — the `| TC-ID |`
+  header, separator rows, and prose lines are skipped (counting them inflated ERP's
+  total by 30). The parse contract MUST ship with a **self-test fixture** so a regressed
+  reporter is caught, not discovered in production counts.
+- **The broken-handle enforcer (what makes any "100%" trustworthy)**: every `Covered-by`
+  handle in **automated form** MUST resolve to a test that exists in the run **and
+  passed** — a cited test that is missing or failing is a **broken handle**, the report
+  exits non-zero, and the gate goes red. **Broken = 0 is the bar.** From the moment this
+  runs, coverage cannot be faked by editing a spec cell (the ERP drive ran ~40 report
+  cycles at broken = 0). Duplicate TC-IDs across files are flagged the same way.
+- **The enforcer is LANE-AWARE (env-pending, the field refinement)**: an
+  automated-form handle whose file cadence is `*.integration/*.e2e/*.smoke` needs a
+  live env — in a lane that lacks it (the unit/Docker gate, a DB-less local run) a
+  missing such test folds to **⏳ `env-pending`** (its own bucket; still *covered*),
+  **never broken** — it is verified in its own CI lane
+  ([`live-harness.md`](live-harness.md), §4 item 4). In the **full lane** (CI job with
+  services / a local live-stack run) the same handle IS enforced: missing or failing
+  ⇒ broken. This is what lets a repo flip `— (manual)` rows to live handles without
+  false-reding the unit gate (the ERP drive ran 244 env-pending handles this way).
+  The lane is an explicit reporter input, never guessed from "did anything fail" —
+  and a **closed set that fails closed**: only `unit` and `full` are valid; any other
+  label (a typo, a CI job name like `integration`) must refuse to run rather than
+  silently un-enforce (the reference reporter exits 2).
+- **Conformance flag**: a suite file living **outside `<app>/tests/epic/EPIC-NN/`** (a
+  flat `tests/*.test.ts`) is **non-conformant** — surface it in the report so the
+  unmigrated layout (test-organization §2) is visible, not silent.
+- **Aggregate to one row per TC-ID** (a TC-ID can back several tests — a `describe`
+  group or parametrized cases). Fold its tests: **any `failed` ⇒ the TC is `failed`**;
+  else **any `skipped` ⇒ `blocked`**; else **`passed`**. One TC-ID → one report row.
+- **Reconcile against the spec, not just the run.** Enumerate every `TC-<EPIC>.<TYPE>-<n>`
+  under `test-cases/EPIC-N/` — `index.md` + every `US-x.y.md` + any layered siblings
+  ([`layered-suites.md`](layered-suites.md); legacy single `EPIC-NN.md` accepted —
+  the scan is **recursive** over `test-cases/`);
+  a TC with **no test in the JSON** is `not-written` (or, if
+  the spec row is flagged manual-only `📋`, `manual`; or, if its `Covered-by` is
+  `PROPOSED:<path>::name`, **planned automation** — still counts as *uncovered*, see
+  [`traceability.md`](traceability.md)) — emit the row anyway. This is mandatory:
+  coverage % (§3) is computed over the **spec's** TC list, so an un-generated TC must
+  count as uncovered instead of silently vanishing (a fresh adoption is mostly this).
+- **Status mapping** — one canonical table from the TC outcome → `report.md` icon → the
+  US plain-word legend (test-organization §5), so the write-back (§3) is deterministic
+  and **lossless** (each report status has a *distinct* US plain-word — `blocked` and
+  `not-written` do not both collapse to `pending`):
+
+  | TC outcome | Source | `report.md` icon | US plain-word |
+  |---|---|---|---|
+  | all tests `passed` | fold (§2) | ✅ pass | `done` |
+  | any `failed` | fold (§2) | ❌ fail | `failed` |
+  | any `skipped` (precondition/dependency unmet) | fold (§2) | ⏸️ blocked | `blocked` |
+  | no test for a spec TC | spec-reconcile | — not-written | `pending` |
+  | spec row flagged manual-only `📋` | spec flag | 📋 manual-only | `manual` |
+  | spec row flagged impl-gap `🚧` | spec flag | 🚧 impl-gap | `impl-gap` |
+  | `Covered-by` = `OPS-DEPLOY:<runbook>` | spec handle | 🏗️ ops-deploy | `ops-deploy` |
+  | automated handle, live cadence, env absent in THIS lane | lane rule (below) | ⏳ env-pending | `env-pending` |
+  | `Covered-by` = `DESIGN-REVIEW:<ref>` | spec handle | 🎨 design | `design` |
+
+  The runner's fold (§2) only ever yields `passed`/`failed`/`blocked`; `manual` and
+  `impl-gap` come from a **spec-row flag** (like manual-only), never guessed from an
+  error string; `not-written` comes from the spec-reconcile step; `ops-deploy` comes
+  from the fourth `Covered-by` form ([`traceability.md`](traceability.md)) and is
+  **counted in its own column — never lumped with `manual`, never claimed as
+  CI-automated**; `design` comes from the fifth form and is resolved by the
+  `/design-review` + design-lint pass, not the runner. `broken` (missing/failing cited test, out-of-set cell, duplicate
+  TC-ID) deliberately has **no row here**: a broken handle turns the gate red and the
+  run stops — it lives in `report.md`'s BROKEN section + the `broken` counter and
+  **never reaches the story write-back (§3)**.
+
+- **Output (date-first)**: write `docs/tests/test-reports/<YYYY-MM-DD>/auto-coverage.md`
+  (the whole-repo machine report: suite totals, the coverage formula — canonical in
+  [`test-organization.md`](test-organization.md) §5 — per-epic bucket table,
+  broken list) + `<YYYY-MM-DD>/EPIC-N/report.md` per epic in the koni-docs
+  `test-report.md` template shape — a row per TC (id · status icon · time · failure
+  detail) + the run header (commit, env, runner) — and refresh the latest-state
+  rollups `test-reports/summary/{system-test-report,us-coverage-summary}.md`
+  ([`test-organization.md`](test-organization.md) §1). These are the **reporter's
+  exclusive artifacts**; manual `MAN-*` runs go in `report-manual.md`.
+  These rows are the reporter's *minimum*; a decision-grade report also carries the
+  content bar of [`report-quality.md`](report-quality.md) (overview %, results by
+  group, skipped/blocked reason+action, perf stats, evidence links).
+- **Path validator (MUST)**: the output path must match the **date-first** shape
+  `test-reports/\d{4}-\d{2}-\d{2}/(auto-coverage\.md|report(-manual|-notes)?\.md|EPIC-[0-9A-Z]+/(report(-manual|-notes)?\.md|US-[\d.]+/(api|functional)-test-cases\.md))`
+  or `test-reports/summary/(system-test-report|us-coverage-summary)\.md` — the
+  **legacy** epic-first `test-reports/EPIC-NN/<MMDDYYYY>/report*.md` is also accepted
+  on repos that already use it (never for a new adoption). Reject anything else
+  before writing — this is the #1 fresh-adoption drift (test-organization §1).
+- **Build it from the reference implementation**: koni-qc ships
+  [`scripts/qc-report.mjs`](../scripts/qc-report.mjs) (node stdlib, + its contract
+  self-test in `scripts/__tests__/qc-report-test.mjs`) — copy it into the repo and adapt
+  paths, or wrap it in a `/run-test EPIC-NN` skill. The *contract* above stays canonical;
+  the repo owns its copy. (This supersedes the earlier "no vendored reporter" stance —
+  CONTEXT D30, reversing D21 on this point: field experience showed every repo re-implementing the contract from
+  prose re-introduces the parse bugs; a reference implementation with a frozen self-test
+  does not.)
+
+## 3. Story write-back (Code → story)
+
+The second half of the reporter — this is what the 3-place sync's "Code → story is
+automated" ([`test-organization.md`](test-organization.md) §3) actually **is**:
+
+- After `report.md`, patch each covered `docs/sprints/stories/US-*.md`: set the TC's
+  **Status** — always the **plain-word** value from the §2 mapping table (`done` /
+  `failed` / `blocked` / `pending` / `impl-gap` / `manual`), never an icon in a US file
+  (test-organization §5) — the **coverage %** (per US = its covered ACs ÷ its ACs,
+  where a TC with no passing test is *not* covered), and the **report link**. Runs are
+  automated → never hand-edit these back.
+- This makes [`quality-bar.md`](quality-bar.md)'s Band-A **"Coverage % reported"**
+  tickable at Execute — it was un-satisfiable before because nothing computed it.
+
+## 4. CI gate + runner bootstrap
+
+The local koni-harness git-hook gate is the fast path; **CI is the enforced gate for
+a cloud repo** (a fresh repo has neither by default — bootstrap both):
+
+1. **Coverage script**: add a `test:cov` script that **enforces** the unit-coverage bar
+   ([`unit-coverage.md`](unit-coverage.md), default ≥80% line-and-branch). The threshold
+   lives in **config**, not a dotted CLI flag — for vitest/jest set
+   `test.coverage.thresholds` / `coverageThreshold` in `vitest.config`/`jest.config`
+   (then `test:cov` = `vitest run --coverage` / `jest --coverage`); only pytest takes it
+   on the CLI (`pytest --cov --cov-fail-under=80`). A run below the bar must exit non-zero.
+2. **CI workflow — match the repo's CI, don't assume GitHub Actions**:
+   - **GitHub Actions repo** → emit `.github/workflows/test.yml` running the TC suite +
+     `test:cov` on every push/PR (optionally typecheck — `tsc --noEmit` — if the repo is
+     typed); it fails the PR below the bar.
+   - **Container-/Docker-built repo (no `.github/workflows`, like ERP-02)** → wire the
+     same `test:cov` into the build gate: a `RUN npm run test:cov` layer in the
+     `Dockerfile` (build fails below the bar) and/or the platform's CI step (GitLab CI,
+     Cloud Build, etc.). The **rule is "the coverage bar runs on every push/PR/build"**;
+     the *file* is whatever that repo's CI actually is — do not leave a repo un-gated just
+     because it isn't on GitHub Actions.
+   This is the server-side counterpart to koni-harness's `pre-push` hook.
+3. **Local gate rows**: add the `tests` + `unit-coverage` `passthrough` rows to
+   `.koni-harness/gates.conf` (koni-harness [`gate-catalog.md`](../../koni-harness/references/gate-catalog.md)),
+   **plus a `typecheck` passthrough row** (`tsc --noEmit`) — the vitest/esbuild `tests`
+   gate does NOT type-check, so a TS error in a generated test can pass the git gate and
+   fail only at deploy (ERP hit 6 such build-breakers).
+4. **Integration + e2e run in a CI job with services, not the deploy gate**: a container
+   build can't host a DB or a browser, so the live suites run in a CI job that (a) boots
+   the local stack (with the boot exclusions of [`live-harness.md`](live-harness.md)),
+   (b) **self-seeds** its own e2e user (never gates on hand-configured secrets), (c) runs
+   the integration + e2e suites on every push/PR, and (d) exposes a `test:all` script for
+   the same run locally. **The live lane must fail if it skipped everything**: the
+   `hasIntegrationEnv` skip-guard ([`live-harness.md`](live-harness.md) property 4) is for
+   env-less lanes — in the *designated* live job, env absent / all live suites skipped
+   (`blocked > 0` for them) is a red run, otherwise a misconfigured env yields a green
+   gate that asserted nothing live. Note: actually *blocking* a merge additionally
+   requires branch protection — a repo setting, not a workflow file.
+
+> **Monorepo / multi-app.** `<app>` is the epic's owning package, not the repo root:
+> `test:cov` goes in **that package's** `package.json`, its `tests/epic/` tree and
+> config live under the package, and the workflow runs it per-app (a matrix or a
+> per-package job). Report paths stay repo-rooted at
+> `docs/tests/test-reports/YYYY-MM-DD/EPIC-N/`.
+
+**"A CI test gate exists"** is a Release-stage exit criterion (see
+[`qc-workflow.md`](qc-workflow.md) §5) — without it the suite silently rots.
+
+## Ownership — the contract is canonical, the reference makes it safe
+
+koni-qc **defines these contracts + the procedure** (portable across vitest / jest /
+pytest / playwright); the **repo's runner executes**; **koni-harness / CI enforces**.
+The skill **ships the reference implementation** ([`scripts/qc-report.mjs`](../scripts/qc-report.mjs)
++ its self-test) precisely because "specified tightly enough that an agent rebuilds it
+from prose" proved false in the field — two rebuilt reporters re-introduced the parse
+bugs (CONTEXT D30, reversing D21 on this point). The repo owns its *copy* (adapted
+paths, extra rollups); the contract in §2 stays the single source of truth, and any
+copy must keep the self-test green. What this section must **not** do is what the
+old wording did: assert that "gstack `qa` or a repo `/run-test`" already automates this
+when a fresh repo has neither.

--- a/.claude/skills/koni-qc/references/test-design.md
+++ b/.claude/skills/koni-qc/references/test-design.md
@@ -1,0 +1,234 @@
+# test-design — derive cases from requirements
+
+> **Load when**: you are turning a story's acceptance criteria into concrete
+> test cases (the **Design** stage of [`qc-workflow.md`](qc-workflow.md)).
+> This file is the *how* of case derivation; [`edge-coverage.md`](edge-coverage.md)
+> is the checklist that guarantees you also cover the unhappy paths;
+> [`traceability.md`](traceability.md) is where the derived cases are recorded
+> (TC-ID + the canonical table) and proven complete (the AC↔TC matrix).
+
+A test case is never invented; it is *derived* from a requirement by a named
+technique. Naming the technique is what makes coverage auditable — a reviewer
+can ask "which partition is this?" and "where is its boundary case?" instead of
+trusting that the author thought of everything. The backup suite skipped this
+step, which is why it landed at ~70% happy-path with no boundary or negative
+coverage. koni-qc makes derivation explicit.
+
+**Contents**: [Deriving cases from an AC](#deriving-cases-from-an-ac) ·
+[Equivalence partitioning](#equivalence-partitioning) ·
+[Boundary-value analysis](#boundary-value-analysis) ·
+[Decision tables](#decision-tables) ·
+[State-transition testing](#state-transition-testing) ·
+[Pairwise / combinatorial](#pairwise--combinatorial) ·
+[Error-guessing](#error-guessing)
+
+---
+
+## Deriving cases from an AC
+
+The procedure, run once per acceptance criterion:
+
+1. **Restate the AC as an input → expected-output contract.** Name every input
+   variable (field, parameter, precondition state) and the observable output
+   (UI state, response, side-effect, error).
+2. **Partition each input** into equivalence classes — the valid classes and
+   *every* invalid class (empty, wrong type, out of range, malformed). One
+   representative per class. (See *Equivalence partitioning* below.)
+3. **Find the boundaries** of every ordered/sized input and add a case at each
+   edge and just past it. (See *Boundary-value analysis*.)
+4. **Combine inputs** when the output depends on more than one — build a
+   decision table or a pairwise set so you test the *combinations*, not just
+   each input alone.
+5. **Walk the states** if the feature has a lifecycle (draft→saved→deleted) —
+   one case per legal transition and the illegal ones.
+6. **Guess the errors** — run the AC through the
+   [`edge-coverage.md`](edge-coverage.md) taxonomy and add the classes it flags
+   (injection, encoding, concurrency, network failure, permission).
+7. **Classify every derived case** as positive / negative / boundary-or-edge and
+   assign it a `TC-<EPIC>.<TYPE>-<n>` ID. The matrix rule
+   ([`traceability.md`](traceability.md)) requires *each AC* to end with **≥1
+   positive AND ≥1 negative AND ≥1 boundary-or-edge** case (a `BND` *or* an `EDGE`
+   case fills the third slot) — if any is missing, the AC is not done.
+8. **If the AC is UI-bearing, add a design-review conformance case (MANDATORY).**
+   Any AC that renders or changes UI **must** get a `TC-<EPIC>.UI-<n>` (or fold it into
+   the relevant `FUNC`/`A11Y` case, per [`nfr.md`](nfr.md) §UI) whose pass condition is:
+   **passes gstack `/design-review` against the repo's `DESIGN.md` AND the shadcn
+   standard** (the full criteria are [`nfr.md`](nfr.md) §UI). The
+   test design is **not done** for a UI AC until this case exists — a UI feature
+   that is functionally green but fails design-review (drifts from DESIGN.md, or
+   hand-rolls a component / bypasses the shadcn tokens) is a failure, so the case
+   that would catch it must be authored up front, not discovered at Execute.
+9. **Cross-multiply the shared classes across every surface (the volume step).**
+   Steps 1–8 derive *per AC* — that alone yields the 3-slot minimum and stops ~10×
+   short of a real suite (the US-001.001 exemplar: **154 cases for one US**; the
+   per-AC floor alone gives ~15). After per-AC derivation, enumerate the US's
+   **surfaces** and multiply each **shared class** across them — every product cell
+   is its own case:
+
+   | Shared class | × every | Example count |
+   |---|---|---|
+   | auth-guard (missing/expired/malformed/wrong-issuer token) | protected **endpoint** | 4 × 7 endpoints |
+   | validation rule (empty/too-short/too-long/boundary/special-chars) | input **field** | 5 × each field |
+   | RLS/permission (owner-read · cross-user isolation · write-rejection) | protected **table** | 3 × 5 tables |
+   | error code / HTTP status | each one the design defines | 1+ each |
+   | domain event (emitted · payload shape · idempotency) | **event** | 3 × each |
+   | provider/platform variant (wallet, browser, OS) | **provider** | 1 × each flow |
+   | UI state (loading/disabled/toast-success/toast-error/empty/persist) | **form/component** | 6 × each |
+
+   Multiplication is **per single surface dimension** (one class × one enumerated
+   surface). When shared classes combine **with each other** (platform × chain-type ×
+   fee-override…), do NOT take the full product — reduce the combination via
+   **pairwise** (step 4), exactly as [`traceability.md`](traceability.md)'s
+   platform-fan-out rule says. Full product across one dimension; pairwise across
+   dimensions.
+
+   Two expansions inside the table deserve spelling out:
+   - **Full BVA per bounded field**: the AC↔TC boundary *slot* is satisfied by ONE
+     two-sided `BND` probe — but the **field × validation matrix** enumerates the
+     full point set as **discrete rows**: `min−1 · min · max · max+1` (add
+     `min+1`/`max−1` where off-by-one logic exists). "One edge row" at the density
+     layer is the collapse that cost the 10×.
+   - **Every state transition, legal AND illegal**: not one case per lifecycle — one
+     per legal transition plus one per *illegal* attempt (edit-after-delete,
+     act-on-archived, re-accept a consumed token…), from step 5's transition walk.
+
+   The [orthogonal matrices](layered-suites.md) then *verify* this multiplication —
+   but they can only catch what this step *generates*. The 3-slot rule is a **floor,
+   not a stopping criterion**: a green matrix with an unmultiplied surface is an
+   under-derived suite.
+
+**One case = one observable behaviour (atomicity).** Never bundle assertions for
+*different* behaviours into one Expected cell — "name too short rejected AND counter
+shows 2/50 AND button disabled" is three cases (one per behaviour) unless they are a
+single indivisible outcome. Atomic cases are countable, individually reportable, and
+fail one-at-a-time; bundled cases hide which behaviour broke and silently deflate the
+suite's real coverage count. (One named exception: the **two-sided `BND` probe** is one
+case *by definition* — it asserts the just-valid accept AND the just-invalid reject of
+the same edge, per [`traceability.md`](traceability.md) §BND vs NEG — do not split it.)
+
+The output of this procedure is rows in the canonical test-case table, ready to
+fill in the koni-docs `test-cases/EPIC-N/` container (`US-x.y.md` per story). For a US with an **API
+surface and/or UI**, shape those rows into the layered-suite structure
+([`layered-suites.md`](layered-suites.md)): the API/functional split, by-endpoint
+tables, and the orthogonal coverage matrices that catch whole missing classes.
+
+---
+
+## Equivalence partitioning
+
+**What it is**: split each input domain into classes that the system should
+treat identically, then test one representative per class. The premise: if one
+value in a class works, they all do — so testing every value is waste, and
+testing only the easy class is a gap.
+
+**When to use**: every input with a "valid range / set" notion — text fields,
+enums, numeric ranges, file types. Always your first pass.
+
+**Worked example** — AC: *"RPC URL must be a reachable http(s) endpoint."*
+Partitions: {reachable https} (valid) · {reachable http} (valid) · {well-formed
+but unreachable} (invalid) · {malformed scheme e.g. `ftp://`} (invalid) ·
+{empty} (invalid). Cases: positive `https://rpc.example.io` → saved; negative
+`https://does-not-exist.invalid` → "Cannot connect to this provider"; negative
+`ftp://x` → reject. Three classes, three cases — none of them happy-path-only.
+
+---
+
+## Boundary-value analysis
+
+**What it is**: errors cluster at the edges of a range, so test the minimum, the
+maximum, and the values immediately inside and outside each (`min-1, min,
+min+1`). Pairs with partitioning: partition finds the classes, boundary tests
+their seams.
+
+**When to use**: any ordered or sized input — string length, numeric limits,
+counts, decimals, pagination size, timeouts.
+
+**Worked example** — AC: *"Token decimals is an integer 0–18."* The BVA probes
+are `0`/`18` (just-valid, accepted) and `-1`/`19` (just-invalid, rejected) —
+together these are **one boundary (`BND`) case** that asserts both the just-valid
+accept *and* the just-invalid reject at each edge (this is how the matrix's
+boundary slot is filled; see the no-double-counting rule in
+[`traceability.md`](traceability.md)). A **negative (`NEG`)** case is different:
+it rejects a value from a *wrong partition* — wrong type or malformed, e.g.
+decimals = `"abc"` — not a value one step past a numeric edge. The backup tested
+only "decimals = 18".
+
+---
+
+## Decision tables
+
+**What it is**: enumerate the combinations of conditions and the action each
+combination should produce, as a table — rows are rules, columns are
+conditions + outcome. Forces you to cover combinations a per-input pass misses.
+
+**When to use**: when the output depends on **multiple** conditions interacting
+(flags, roles × states, validation rules that compound).
+
+**Worked example** — AC: *"Save a network only if RPC reachable AND name
+non-empty AND not a duplicate."*
+
+| RPC reachable | Name present | Duplicate | → Outcome |
+|---|---|---|---|
+| Y | Y | N | save (positive) |
+| N | Y | N | "Cannot connect" |
+| Y | N | N | "Name required" |
+| Y | Y | Y | "Network already exists" |
+
+Four rules → four cases, one positive, three negative — each independently
+verifiable.
+
+---
+
+## State-transition testing
+
+**What it is**: model the feature as states + the events that move between them,
+then test every legal transition and assert that illegal transitions are
+refused. Catches lifecycle bugs (acting on a deleted record, editing while
+saving).
+
+**When to use**: any feature with a lifecycle — created/active/deprecated,
+draft/published, linked/unlinked, in-use/idle.
+
+**Worked example** — AC: *"Cannot delete a network currently in use."* States:
+`idle → (delete) → removed`; `in-use → (delete) → BLOCKED`. Cases: positive
+delete an idle custom network → removed; negative delete an in-use/active
+network → refused with a clear message and the network still present.
+
+---
+
+## Pairwise / combinatorial
+
+**What it is**: when full combination testing explodes, generate the smallest
+set of cases that covers every *pair* of parameter values — most defects are
+triggered by a single value or a pair, so pairwise gets ~the coverage of
+exhaustive at a fraction of the cases.
+
+**When to use**: many independent parameters (platform × chain-type × override
+× network-state) where the full cross-product is infeasible.
+
+**Worked example** — parameters: platform {extension, mobile} × chain-type
+{EVM, Substrate} × user-override {none, name, decimals}. Full cross-product =
+2×2×3 = 12; a pairwise set covers every pair in ~6 cases — e.g. (extension, EVM,
+none), (extension, Substrate, name), (mobile, EVM, decimals), (mobile,
+Substrate, none), (extension, EVM, decimals), (mobile, Substrate, name). Tag the
+platform dimension in the canonical table's platform-variant column.
+
+---
+
+## Error-guessing
+
+**What it is**: the experience-driven pass — deliberately try the inputs known
+to break software: empty, whitespace-only, paste of 10k chars, emoji, leading
+zeros, a script tag, a doubled tap, the back button mid-save. Structured here as
+the [`edge-coverage.md`](edge-coverage.md) taxonomy so it is a checklist, not a
+mood.
+
+**When to use**: last pass on every AC, after the systematic techniques — it
+catches what the model missed.
+
+**Worked example** — AC: *"Enter a network name."* Error-guesses → name =
+`<script>alert(1)</script>` (injection → must be sanitized/escaped, see
+[`nfr.md`](nfr.md) §Security); name = `"  "` (whitespace-only → reject); name =
+`日本語ネット🌐` (encoding/emoji → stored and rendered intact); name = 256× `a`
+(boundary → length cap enforced). Each becomes a real `TC-CN.*` row in the
+pilot.

--- a/.claude/skills/koni-qc/references/test-organization.md
+++ b/.claude/skills/koni-qc/references/test-organization.md
@@ -1,0 +1,264 @@
+# test-organization — the standard test-doc & test-code layout
+
+> **Load when**: setting up a repo's test surface, or deciding *where* a test
+> doc / test file goes. This is the **compass** — the folder taxonomy, the
+> by-epic + suffix code layout, the 3-place sync rule, and the status legend.
+> It is the standing standard; [`traceability.md`](traceability.md) owns the
+> TC-ID scheme and the AC↔TC matrix, this owns *where things live*.
+
+**Contents**: [Granularity: the unit is the US](#0-granularity-the-unit-is-the-user-story-not-the-epic) ·
+[docs/tests taxonomy](#1-the-docstests-taxonomy) ·
+[Test-code layout](#2-test-code-layout-by-epic-type-in-the-suffix) ·
+[The 3-place sync rule](#3-the-3-place-sync-rule) ·
+[State cleanup](#4-state-cleanup--idempotent-tests) ·
+[Status legend](#5-status-legend) · [Scaffolding](#6-scaffolding-who-creates-the-tree) ·
+[Ownership](#7-ownership-boundary)
+
+Synthesized from the matured Senti-Quant QA reorg (2026-06-30) and generalized
+for any Koniverse repo.
+
+## 0. Granularity: the unit is the **user story**, not the epic
+
+**Coverage, traceability, and QC planning are measured and tracked per US — not
+per epic.** An epic is too coarse: "EPIC-04 is tested" hides that only 14 of its N
+stories have a case. The honest, actionable unit is the story.
+
+- **Coverage %** = (done stories with ≥1 covering TC) ÷ (done stories). Never
+  "epics tested". A story counts as covered only when a real TC's `maps_to.us`
+  points at it (see [`traceability.md`](traceability.md)).
+- **The QC backlog is a per-US, risk-tiered list** — every shipped (`done`) story
+  with no covering TC is a row, ordered Tier 1 (security / money / external
+  surface) → Tier 2 (core data / perf) → Tier 3 (UI / lower-risk). This *by-US
+  coverage plan* is the planning artifact, which **MUST live at
+  `audits/QC-PLAN-BY-US-<date>.md`** (never the tests root), not an epic checklist.
+  Standing up whole-repo coverage (the QA-tracking epic + this plan + the
+  done-bar) is [`whole-project-qc.md`](whole-project-qc.md).
+- **The AC↔TC matrix is anchored per story** (one block per US, its ACs → TCs) —
+  this is already how `traceability.md` works.
+
+**Case *volume* per US is doc-driven, not invented at the keyboard**: authoring for a
+US may only start once Frame has secured its enumeration inputs — the technical-design
+contract + UI-state inventory for the surfaces the US has
+([`qc-workflow.md`](qc-workflow.md) §1) — because density is *derived* from those docs
+([`test-design.md`](test-design.md) step 9), and a US authored straight from its AC
+list silently lands at 1/10 density.
+
+**Epic stays the *container*, US is the tracked *unit*.** Specs group by epic
+(`test-cases/EPIC-N/` — a directory: `index.md` + one `US-x.y.md` per story, §1),
+test code by epic (`…/epic/EPIC-NN/`), reports by date→epic — but inside them every
+TC carries its `maps_to.us`, and what you *measure and plan* is the story. Don't
+confuse the folder grouping (epic) with the coverage unit (US).
+
+## 1. The `docs/tests/` taxonomy
+
+Adopted from the ERP-02 field reorg (2026-07-02, at ~430–450 authored TCs and
+264→531 passing tests) — **specs split per-US, reports date-first**:
+
+```
+docs/tests/
+├── README.md             ← QA hub (entry point; links the coverage epic)
+├── test-organization.md  ← STANDING: this standard (points here)
+├── STRATEGY.md           ← STANDING: whole-repo test strategy (scope · risk posture · priority order · tooling)
+├── findings.md           ← STANDING: open QA findings / impl-gap tracker (+ the change-coverage ledger, regression-learning.md)
+├── test-cases/           ← CANONICAL source specs (machine-read by the reporter)
+│   └── EPIC-N/           ← one DIRECTORY per epic (not a single file)
+│       ├── index.md         epic overview: scope · out-of-scope · stories-in-scope
+│       │                    table · AC↔TC matrix · US index · open/deferred scenarios
+│       └── US-x.y.md        that story's rich TC rows + Covered-by handles
+│                            (split further into US-x.y-api/functional siblings inside
+│                             the epic dir when a layer exceeds ~15 cases, layered-suites.md)
+├── test-reports/         ← per-run output, DATE-FIRST (regenerated; never hand-edited)
+│   ├── YYYY-MM-DD/          one folder per run day (a run day covers MANY epics)
+│   │   ├── auto-coverage.md    the machine coverage report (whole-repo, reporter-written)
+│   │   └── EPIC-N/
+│   │       ├── report.md          per-US index (summary + links)
+│   │       ├── report-notes.md    QC-driver narrative (report-quality.md)
+│   │       ├── report-manual.md / img-manual/   manual runs
+│   │       └── US-x.y/            detailed per-US execution docs, ONE format for
+│   │           │                  every epic (generated from the spec + the run):
+│   │           ├── functional-test-cases.md   (UI / e2e)
+│   │           └── api-test-cases.md          (backend / RLS / pure-helper)
+│   └── summary/             LATEST-STATE roll-ups (regenerated each run):
+│       ├── system-test-report.md    every TC + status, EPIC→US, for total review
+│       └── us-coverage-summary.md   per-US coverage rollup
+├── bug-bash/             ← end-of-sprint bug-bash reports — sprint-YYYY-WNN.md
+└── audits/               ← point-in-time analyses (dated, historical; not maintained)
+```
+
+| Folder / file | Owner | Purpose |
+|---|---|---|
+| `STRATEGY.md` | QA | **whole-repo** test strategy — cross-epic scope, risk posture, priority order, tooling (a repo MAY instead keep strategy in dedicated stories, the ERP-02 variant — but then README must link them) |
+| `test-cases/EPIC-N/` | koni-qc (Dev/PM) | the source specs — `index.md` (epic frame + AC↔TC matrix) + per-US TC-row files; the **single source of truth** for TC-IDs and `Covered-by` handles |
+| `test-reports/` | the reporter (auto) | per-run output + latest-state `summary/`; **never hand-edited** (manual runs use `report-manual.md`) |
+| `bug-bash/` | whole team | end-of-sprint break-it-together findings — feeds [`regression-learning.md`](regression-learning.md) |
+| `audits/` | QA | dated one-off analyses (e.g. a koni-qc quality-bar grade); kept for history |
+
+> **No `test-plan/` folder.** The per-epic plan content (scope, out-of-scope, risk
+> map, priority order) lives in that epic's `test-cases/EPIC-N/index.md` — one place,
+> next to the cases it frames (ERP-02 removed the folder 2026-07-02 after it went
+> stale against the index files). Whole-repo strategy stays `STRATEGY.md` (or the
+> stories variant above).
+
+> **Why per-US spec files**: the US is the coverage unit (§0) and at real density
+> (~40–150 cases/US) a single `EPIC-N.md` blows past what a reviewer or an agent can
+> hold — the epic file's job (frame + matrix + index) and the story files' job (the
+> rows) are different documents. `index.md` NEVER carries TC rows; a `US-x.y.md`
+> NEVER re-frames scope.
+>
+> **Legacy accepted**: a repo already on the single-file `test-cases/EPIC-NN.md`
+> layout keeps working (the reporter scans both); migrate to `EPIC-N/` on the next
+> authoring pass that touches the epic. New adoptions use the directory layout.
+
+> **The report path is a MUST, not a suggestion.** A run folder is
+> **`test-reports/YYYY-MM-DD/`** (ISO date, one per run day) with per-epic subfolders
+> — a run day covers many epics, so the date owns the folder and each epic nests
+> inside (the old epic-first `EPIC-NN/<MMDDYYYY>/` shape created N duplicate date
+> folders per run; it is **legacy-accepted**, and the validator in
+> [`test-automation.md`](test-automation.md) §2 accepts both — new adoptions are
+> date-first). `auto-coverage.md` (the whole-repo machine report) lives at the date
+> level, not inside an epic. The first run must not invent its own layout.
+
+> **Relationship to koni-docs (report layout vs report body).** koni-qc owns this
+> **layout**; **koni-docs owns the report *body* templates** (per-execution +
+> per-release aggregate). This layout supersedes koni-docs' older
+> `test-reports/{runs,releases}/` path wherever koni-qc is adopted; a release-level
+> rollup is still a koni-docs per-release report, placed under the same tree.
+> (koni-docs' own `sprint-system.md`/`templates.md` still reference the legacy
+> path — reconciling them to this layout is a tracked koni-docs follow-up.)
+
+## 2. Test-code layout: by epic, type in the suffix
+
+Test **code** (not docs) is organized **by epic, never by test type**:
+
+```
+<app>/tests/epic/EPIC-NN/<slug>.<cadence>.spec.ts
+```
+
+The **run cadence** is encoded in the file SUFFIX (not a sub-folder):
+
+| Suffix | Cadence / runner | When |
+|---|---|---|
+| `*.integration.spec.ts` | API / server-side (calls actions directly) | per commit |
+| `*.e2e.spec.ts` | end-to-end via real UI | per PR |
+| `*.smoke.spec.ts` | light post-deploy smoke (real anchor) | per deploy / release |
+| `*.unit.test.ts` | pure logic, per function (**Dev authors; koni-qc owns the unit-coverage bar, harness Self-verify enforces** — see [`unit-coverage.md`](unit-coverage.md)) | — |
+
+- **No `integration/` or `e2e/` sub-folders** — keep files flat in the epic folder;
+  group cases inside a file with `describe`.
+- **A flat repo-root `tests/*.test.ts` layout is non-conformant — migrate it, don't
+  tolerate it.** On adoption, if the repo already has flat suites (common in
+  OpenSaaS/Vite-inherited repos), **generate the `<app>/tests/epic/EPIC-NN/` tree and
+  move (or re-export) each suite into its epic folder** — do not leave "migrate as you
+  go" open-ended, because it becomes "never" (the ERP-02 drift). The reporter
+  ([`test-automation.md`](test-automation.md) §2) flags any suite living outside
+  `tests/epic/` as non-conformant so the gap is visible, not silent.
+- **Suffix ≠ TC-ID TYPE.** The TC-ID TYPE (`FUNC`/`NEG`/`BND`/`SEC`/`EDGE`/… per
+  [`traceability.md`](traceability.md)) says *what the case tests*; the file suffix
+  says *how/when it runs*. A `TC-NN.SEC-1` can live in an `.integration.spec.ts`
+  or `.e2e.spec.ts` file depending on its cadence. Keep koni-qc's TYPE-based TC-ID;
+  feature grouping (LINK/CRED/…) is expressed via the domain-prefix allowance in
+  `traceability.md`, not by moving type out of the code.
+
+## 3. The 3-place sync rule
+
+One TC-ID threads through **three** places; change one → change all three:
+
+> **The spec is the *sole authority* for a TC-ID.** A TC-ID means **one** thing across
+> all three places. A Dev-authored unit file must **not coin its own** `TC-<EPIC>.<TYPE>-<n>`
+> for a *different* case — reusing a spec ID for a different behaviour (the ERP-02 F-12
+> collision, where `crypto.test.ts` `FUNC-3/BND-1/NEG-1` meant something other than the
+> same IDs in `EPIC-2.md`) breaks sync silently. If a unit test asserts a spec'd case,
+> reuse that case's ID; if it covers something the spec doesn't, it is a per-function
+> unit test — name it by function+behaviour, **not** a TC-ID ([`unit-coverage.md`](unit-coverage.md)).
+> The reporter flags any code TC-ID absent from the spec (orphan) or bound to a different
+> case (collision).
+
+1. **Source spec** — `docs/tests/test-cases/EPIC-N/US-x.y.md` (the source of truth: TC-ID + gherkin + yaml **`maps_to {us, fr, ac}`** — the `us` is mandatory; it's what makes per-US coverage computable, §0; legacy single `EPIC-NN.md` accepted, §1). Written *before* coding.
+2. **Test code** — `…/tests/epic/EPIC-NN/<slug>.<cadence>.spec.ts`; the test name **starts with the TC-ID** so the reporter can parse it.
+3. **Coverage story** — the `docs/sprints/stories/US-*.md` row: TC-ID → Status + coverage % + report link.
+
+- **Spec → code** is a **generation step**, not manual copying — see
+  [`test-automation.md`](test-automation.md) §1 (spec → runnable TC-ID-named test;
+  it also materialises the `tests/epic/EPIC-NN/` tree, which the doc scaffold §6
+  does *not* create).
+- **Code → story** is automated by the **reporter contract**
+  ([`test-automation.md`](test-automation.md) §2–§3): run → parse the TC-ID from each
+  test name → write `report.md` → write back Status + coverage % + link to the story.
+  koni-qc defines that contract (it is *not* gstack `qa`, which is browser QA only).
+  Never hand-edit `test-reports/`.
+
+## 4. State cleanup / idempotent tests
+
+**What a test creates, the same test removes.** A test that links an account,
+deploys, or creates a share-link MUST delete exactly that data when done, in an
+`afterEach`/`finally` (runs even on mid-test failure) via a fixture cleanup
+helper — only what it created, never pre-existing data. Tests must be idempotent:
+same outcome every run. Read-only cases need no cleanup. (This is the operational
+half of the reliability axis in [`nfr.md`](nfr.md).)
+
+## 5. Status legend
+
+- **Test-case spec files** (`test-cases/EPIC-N/*.md`) — icons OK: ✅ pass · ❌ fail
+  (reproducible) · ⚠️ flaky · ⏸️ blocked · ⏳ env-pending · 🎨 design · 🚧 impl-gap ·
+  📋 manual-only · 🏗️ ops-deploy · ⊘ retired · — not-written. (The word set `Not Executed / Pass / Fail / Blocked /
+  Skipped` in [`traceability.md`](traceability.md)'s canonical Status column is the
+  **pre-run** vocabulary for the same cell — `Not Executed` ≙ `— not-written` before a
+  run, `Skipped` ≙ ⏸️ blocked; after a run the reporter's icon set above is
+  authoritative. ⚠️ flaky and ⊘ retired are curation states the reporter never emits.)
+- **US story files** (`sprints/stories/US-*.md`) — **plain words, no icons**
+  (machine-parsed, diff-able): `done` · `failed` · `blocked` · `pending` ·
+  `env-pending` · `design` · `impl-gap` · `manual` · `ops-deploy` · `covered-by X` ·
+  `in-progress`. (`blocked` = a test ran
+  but a precondition/dependency was unmet, distinct from `pending` = no test yet —
+  the reporter write-back keeps them separate, see
+  [`test-automation.md`](test-automation.md) §2.)
+- **Run reports** — icons follow what the reporter emits; do not hand-edit.
+- **The coverage formula (what counts as covered)** — field-proven at the ERP 100%
+  drive: **covered = 🟢 automated + ⏳ env-pending + 🎨 design + 🏗️ ops-deploy**.
+  `env-pending` is a **derived, lane-aware status**, not a Covered-by form: an
+  automated-form handle whose file cadence is `*.integration/*.e2e/*.smoke` counts
+  env-pending in a lane without that env (unit/Docker gate) — it is **verified in its
+  own CI lane** ([`test-automation.md`](test-automation.md) §2/§4) and never counted
+  broken locally. `design` comes from the fifth Covered-by form
+  ([`traceability.md`](traceability.md)). `manual` and `PROPOSED:` are the two
+  buckets that count as **uncovered** — driving them to zero is the 100% target.
+
+## 6. Scaffolding: who creates the tree
+
+- **If the repo is set up with koni-setup** — koni-setup creates **both** skeletons at
+  bootstrap: the `docs/tests/` doc tree **and** the `<app>/tests/epic/` **code** root
+  (it owns the directory skeleton; bodies come from koni-docs templates and this
+  standard). Scaffolding *only* the doc tree — the historical gap — is what let a repo
+  keep flat `tests/*.test.ts` with no forcing function to migrate (see §2).
+- **If the repo does NOT use koni-setup** — koni-qc **self-scaffolds** the missing
+  trees (additive, only writes absent paths — **both** the doc tree and the code root):
+
+```sh
+mkdir -p docs/tests/test-cases docs/tests/bug-bash docs/tests/audits   # spec dirs test-cases/EPIC-N/ are created per epic at authoring time
+[ -f docs/tests/README.md ]            || printf '# docs/tests — QA hub\n\n> See test-organization.md for the standard.\n' > docs/tests/README.md
+[ -f docs/tests/test-organization.md ] || printf '# Test organization\n\n> Follows koni-qc references/test-organization.md.\n' > docs/tests/test-organization.md
+[ -f docs/tests/STRATEGY.md ]          || printf '# Test strategy\n\n> Whole-repo test strategy: scope · risk posture · priority order · tooling. Per-epic framing lives in test-cases/EPIC-N/index.md.\n' > docs/tests/STRATEGY.md
+[ -f docs/tests/findings.md ]          || printf '# Open QA findings\n' > docs/tests/findings.md
+[ -f docs/tests/test-cases/README.md ] || printf '# Test cases\n\n> One EPIC-N/ dir per epic: index.md (frame + matrix) + US-x.y.md (rows) — via koni-docs templates/test-cases.md\n' > docs/tests/test-cases/README.md
+# the CODE tree — the doc scaffold historically stopped here; create it too (<app> = the package that owns tests):
+mkdir -p "${APP:-.}/tests/epic" && [ -e "${APP:-.}/tests/epic/.gitkeep" ] || : > "${APP:-.}/tests/epic/.gitkeep"
+# report folders are created on first run: docs/tests/test-reports/YYYY-MM-DD/ (+ summary/)
+```
+
+> **READMEs**: the three root standing docs always exist; `test-cases/` also
+> carries a one-line `README.md` (it's the most-edited subdir). The other empty
+> framework dirs (`bug-bash/`, `audits/`) are kept in git with a `.gitkeep` rather
+> than a stub, and `test-reports/` isn't created until a run.
+
+Only create `test-reports/YYYY-MM-DD/` when a run actually produces a report —
+don't pre-create empty dated folders.
+
+## 7. Ownership boundary
+
+koni-qc owns this **standard** (where test docs live + the conventions);
+**koni-docs** owns the doc-body **templates** that fill `test-cases/` /
+`test-report.md`; **koni-setup** **scaffolds** the tree at setup; the **repo's test
+runner + the reporter contract** ([`test-automation.md`](test-automation.md) §2) run
+the code tests and emit `report.md` (**gstack** runs only interactive/browser QA +
+`/design-review`, not the automated suite); **koni-harness** gates the commit. koni-qc
+composes them — it never reproduces a template, a runner, or the scaffolder.

--- a/.claude/skills/koni-qc/references/traceability.md
+++ b/.claude/skills/koni-qc/references/traceability.md
@@ -1,0 +1,275 @@
+# traceability — the AC↔TC matrix, TC-ID scheme, and the canonical table
+
+> **Load when**: you are recording derived cases and proving the suite complete
+> (the **Design** + **Self-review** stages of [`qc-workflow.md`](qc-workflow.md)).
+> This is the spine of koni-qc — the one artifact **neither** corpus had. The
+> backup left AC↔TC traceability implicit; Koni-Finance had rich per-TC tables
+> but no full coverage matrix. koni-qc makes the matrix mandatory and the gate.
+
+Traceability answers two questions a reviewer must be able to answer in seconds:
+*"is every requirement tested?"* (no orphan AC) and *"does every test trace to a
+requirement?"* (no orphan TC). Without it, a 250-case suite can still leave a
+critical AC untested and nobody notices. With it, coverage is provable.
+
+**Contents**: [TC-ID scheme](#tc-id-scheme) ·
+[The canonical test-case table](#the-canonical-test-case-table) ·
+[AC↔TC coverage matrix](#actc-coverage-matrix) ·
+[Risk-based priority & regression](#risk-based-priority--regression) ·
+[koni conventions preserved](#koni-conventions-preserved)
+
+---
+
+## TC-ID scheme
+
+Every test case carries a stable ID: `TC-<EPIC>.<TYPE>-<n>`.
+
+- `<EPIC>` — the epic number (`02`) or a short domain slug for a feature suite
+  (`CN` for customize-network). Domain prefixes (Koni-Finance style — `NONCE-`,
+  `RLS-`, `SEC-A01-`) are allowed *inside* a suite for sub-areas.
+- `<TYPE>` — one of:
+
+  | TYPE | Meaning |
+  |---|---|
+  | `E2E` | end-to-end flow spanning ≥2 stories |
+  | `FUNC` | functional behaviour of a single capability |
+  | `API` | request/response contract at a service boundary |
+  | `REG` | regression — guards a previously-fixed bug or invariant |
+  | `SMK` | smoke — fast post-deploy sanity |
+  | `SEC` | security — authn/authz, injection, data isolation |
+  | `PERF` | performance — latency/throughput vs an SLA |
+  | `A11Y` | accessibility — keyboard, screen-reader, contrast |
+  | `UI` | visual conformance to `DESIGN.md` **+ the shadcn standard** (via gstack `/design-review`; criteria in [`nfr.md`](nfr.md) §UI) |
+  | `NEG` | negative — invalid/error input is rejected cleanly |
+  | `BND` | boundary — at/just-past a limit (min/max/zero/overflow) |
+  | `EDGE` | edge — concurrency, network-failure, encoding, state races |
+
+  `FUNC`/`SMK`/`E2E`/`API` carry happy-path coverage; `NEG`/`BND`/`EDGE` carry the
+  off-path coverage the matrix demands; `SEC`/`PERF`/`A11Y` carry the
+  non-functional axes. The TYPE code names the *category*; the matrix's
+  *Types covered* column records the positive/negative/boundary *classification*
+  independently (a `TC-CN.SEC-1` XSS case is category SEC, classification negative).
+
+- `<n>` — sequential within (epic, type), starting at `1`.
+
+**Never renumber.** A removed TC keeps its number (marked deprecated) so
+cross-references in test-reports, lessons, and PRs survive. This matches the
+koni-docs `test-cases/EPIC-N.md` convention exactly — koni-qc adds the extra
+TYPEs (FUNC/API/SEC/PERF/A11Y/UI/NEG/BND/EDGE) on top of koni-docs' core set, it
+does not replace the scheme.
+
+> **The TC-ID's `<EPIC>` is an ID namespace, not the coverage unit** — coverage is
+> measured per **US** (see [`test-organization.md`](test-organization.md) §0). Every
+> case carries a mandatory **`maps_to`** linking it to the story it covers, e.g.:
+>
+> ```yaml
+> # in docs/tests/test-cases/EPIC-N/US-x.y.md, per TC
+> TC-02.LINK-1:
+>   maps_to: { us: US-2.1, fr: FR-12, ac: AC-1 }   # us is mandatory
+> ```
+> A case may map to several ACs (`ac: [AC-1, AC-3]`); a story is "covered" once
+> ≥1 TC's `maps_to.us` points at it.
+
+---
+
+## The canonical test-case table
+
+The rich per-TC table, adopted verbatim from the Koni-Finance production
+standard. Every functional/edge case is one row. The columns are fixed:
+
+`TC-ID | Name | Priority | Test data | Preconditions | Action/Request | Expected | Actual | Status | Perf | Side-effects | Covered-by`
+
+| TC-ID | Name | Priority | Test data | Preconditions | Action/Request | Expected | Actual | Status | Perf | Side-effects | Covered-by |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| TC-XX.FUNC-1 | Add reachable EVM network | Critical | `https://rpc.ankr.com/eth` | Manage Network open, network not present | + → paste RPC → auto-detect → Save | EVM detected; name/symbol/decimals/chainId auto-filled; network appears in selector | — | Not Executed | detect < 2.0s | 1 row added to custom-network store | — (manual) |
+| TC-XX.SEC-1 | Reject script in network name | Critical | name `<script>alert(1)</script>` | Manage Network open | enter name → Save | name stored escaped; rendered as literal text; no script executes | — | Not Executed | n/a | no DOM injection in selector | `epic/EPIC-CN/customize-network.e2e.spec.ts::TC-XX.SEC-1` |
+
+> These two rows use placeholder IDs (`TC-XX.*`) so they don't collide with a real
+> suite's IDs. The **`Covered-by`** handle has **five** fixed forms:
+> 1. `<path>.spec.ts::<name>` — **covered** (the automated test exists and ran). The
+>    path is relative to the test root (`epic/EPIC-NN/…` is fine; the `<app>/tests/`
+>    prefix may be omitted), and `<name>` may be abbreviated to the test's leading
+>    TC-ID token (`…spec.ts::TC-01.WS-5`) since that token is the reporter's parse key;
+> 2. `PROPOSED:<path>::<name>` — **planned automation**: the test is intended at that
+>    path/name but the file does **not exist yet** (dominant on a fresh adoption). It
+>    records author intent so the target survives in the spec, but it counts as
+>    **uncovered** for coverage % until it becomes form 1 — the reporter treats it as
+>    `not-written` ([`test-automation.md`](test-automation.md) §2);
+> 3. `— (manual)` — **manual-only**, never automated.
+> 4. `OPS-DEPLOY:<runbook-ref>` — **deploy-verified**: the case checks infra-migration /
+>    deploy-topology / one-time external-integration setup (prod parity, real object
+>    store, multi-replica, credential config, one-shot backfill) that is **not
+>    CI-reproducible**. It counts as *covered* — verified by the referenced deploy
+>    runbook — tracked in **its own column**, never lumped with `manual` and never
+>    claimed as CI-automated. **Hard rule: exhaust the locally-testable core first** —
+>    a TC is ops-deploy only for the irreducibly-prod remainder (ERP pulled 4 such TCs
+>    back into real unit tests before tagging the rest).
+>
+> 5. `DESIGN-REVIEW:<route-or-page>` — **design-verified**: a visual/design-conformance
+>    case (typically `TC-<EPIC>.UI-<n>`) whose execution mechanism is gstack
+>    **`/design-review`** against `DESIGN.md` + the shadcn standard
+>    ([`nfr.md`](nfr.md) §UI) **plus** the repo's static design lint where present —
+>    not a unit/e2e assertion. It counts as *covered* in **its own `design` column**
+>    (🎨), never lumped with `manual` (the ERP 100% drive tracked 22 such cases).
+>    Only for what a runner genuinely cannot assert — a badge state a jsdom test CAN
+>    check is automated-form, not design-form.
+>
+> Do **not** invent a sixth form — these five are the closed set (they replace ad-hoc
+> notes like the ERP-02 free-text markers; the reporter flags any other cell as a
+> broken handle). Legacy free-text cells containing `design-review` are read as form 5 **only when
+> the cell matches no fixed form and is not an automated `::` handle** (a
+> `PROPOSED:` cell or a test file merely *named* design-review stays uncovered /
+> enforced — no laundering); normalize them to `DESIGN-REVIEW:<ref>` when touched.
+>
+> **N scenarios may share one test**: a single automated test MAY assert several
+> scenarios, but the spec still carries **N distinct TC-IDs**, each `Covered-by`
+> pointing at that same `file::name` handle — bundling at the *spec* layer is what
+> hides missing sub-scenarios; bundling at the *test* layer is fine.
+
+Column contract:
+- **Priority** — `Critical / High / Medium / Low`, derived from risk (see §Risk-based priority). (Matches the Koni-Finance production standard.)
+- **Test data** — a concrete, reusable value, never "some valid input".
+- **Preconditions** — the system state before the action (the Gherkin *Given*).
+- **Action/Request** — the user action or the API request (the *When*).
+- **Expected** — the observable outcome + invariant (the *Then*).
+- **Actual / Status** — filled at execution; `Not Executed / Pass / Fail /
+  Blocked / Skipped` (Koni-Finance vocabulary). Execution *history* lives in
+  koni-docs `test-report.md`, not here — this column is only the current state.
+- **Perf** — measured time **or** the SLA target the case asserts (see
+  [`nfr.md`](nfr.md) §Performance).
+- **Side-effects** — DB writes, store mutations, events, files — the things a
+  reviewer can't see in the UI.
+- **Covered-by** — the automation handle (`*.spec.ts::name`), `PROPOSED:<path>::name`
+  (planned, still uncovered), `— (manual)`, `OPS-DEPLOY:<runbook-ref>`, or
+  `DESIGN-REVIEW:<ref>` (see the five fixed forms above).
+
+> The koni-docs `test-cases/EPIC-N.md` container also supports a Gherkin
+> Given/When/Then block per scenario. Use the canonical table for the dense
+> per-case grid; promote a flow to a full Gherkin H3 when it spans ≥2 stories.
+> koni-qc supplies the columns; koni-docs supplies the file structure — do not
+> duplicate the koni-docs template here, fill it.
+
+---
+
+## AC↔TC coverage matrix
+
+**The mandatory artifact. The gate. The thing both corpora lacked.**
+
+Every story's acceptance criteria are listed, each mapped to the TCs that cover
+it and the case *types* those TCs span. **The matrix is anchored per user story
+(`US-X.Y`), not per epic** — the story is the unit of coverage (see
+[`test-organization.md`](test-organization.md) §0). Each TC therefore carries a
+mandatory **`maps_to.us`** (plus `fr`/`ac`); **coverage % is computed per US** —
+(done stories with ≥1 covering TC) ÷ (done stories) — never "epics tested".
+
+| Story | AC | AC description | Positive | Negative | Boundary/edge |
+|---|---|---|---|---|---|
+| US-X.Y | AC-1 | Add a reachable network → appears in selector | TC-XX.FUNC-1 | TC-XX.NEG-1 | TC-XX.EDGE-3 |
+| US-X.Y | AC-2 | Reject duplicate network | TC-XX.SMK-1 | TC-XX.NEG-3 | TC-XX.BND-3 |
+
+**The completeness rule (non-negotiable):**
+
+> Every AC has **≥1 positive AND ≥1 negative AND ≥1 boundary-or-edge** TC
+> (a `BND` *or* an `EDGE` case satisfies the third slot). **No orphan AC** (an AC
+> with no TC). **No orphan TC** (a TC that maps to no AC). **Every UI-bearing AC also
+> has a UI-conformance TC** (a `UI` case — or folded `FUNC`/`A11Y` — asserting
+> `/design-review` vs DESIGN.md + the shadcn standard, [`nfr.md`](nfr.md) §UI). If any
+> holds, the suite is incomplete and does not pass the gate.
+>
+> **No double-counting**: a single TC satisfies **at most one** of the
+> positive / negative / boundary-or-edge slots for a given AC. If an AC's only
+> negative is also its only boundary case, it is missing one class — add a
+> distinct case.
+>
+> **BND vs NEG (the one classification rule that keeps the slots distinct):** a
+> `BND` case is a min/max±1 *boundary probe* that asserts **both** the just-valid
+> accept and the just-invalid reject at an edge (one case, the boundary slot). A
+> `NEG` case rejects a value from a **wrong partition** — wrong type, malformed,
+> missing, unauthorized — *not* a value one step past a numeric edge. So
+> "decimals = 19" is `BND`; "decimals = `abc`" is `NEG`. (See the BVA worked
+> example in [`test-design.md`](test-design.md).)
+>
+> **Prefer a value-boundary for the third slot**: when the AC has an ordered/sized
+> input, fill the boundary slot with a real `BND` case that probes both sides of
+> the edge; fall back to an `EDGE` case (concurrency, network-failure, encoding)
+> only when the AC has no natural value boundary. For a **non-ordinal predicate**
+> (uniqueness, membership, a name collision — no numeric min/max), a `BND` case
+> may probe a single side of the equivalence-class edge (the just-inside-accept
+> *or* the just-outside-reject), since there is no two-sided numeric edge to assert.
+
+A **rejection-style AC** (e.g. *"reject an invalid RPC"*) still gets all three:
+its *positive* is the valid-input-accepted case (the inverse the rule protects),
+its *negative* is the rejection case(s), its *boundary* is the just-valid /
+just-invalid edge. There is no "where applicable" escape — if a class seems
+impossible, the AC is usually under-specified; re-read it via
+[`test-design.md`](test-design.md) before declaring a class N/A, and if truly
+N/A, log it in *Open / deferred* with the reason (never silently blank).
+
+How it is enforced:
+- An AC missing any of positive/negative/boundary → return to
+  [`test-design.md`](test-design.md) and derive the missing class (boundary via
+  boundary-value analysis, negative via partitioning + the
+  [`edge-coverage.md`](edge-coverage.md) taxonomy).
+- An orphan TC → either it tests an unwritten requirement (raise it as a
+  PRD/story gap) or it is dead weight (remove it).
+- An orphan AC → write the cases; until then it is logged in *Open / deferred*
+  with an owner and target.
+
+This matrix is checked in **Self-review** against
+[`quality-bar.md`](quality-bar.md) (Band-A) and again by the author-blind review.
+It is the single most important difference between a koni-qc suite and the backup.
+
+> **The AC↔TC matrix proves *requirements* coverage; the orthogonal matrices prove
+> *surface* coverage.** For an API/UI suite, pair it with the endpoint /
+> HTTP-status-code / error-code (API) and pages / components / validation+a11y
+> (functional) matrices from [`layered-suites.md`](layered-suites.md) — a status code
+> or page with zero TCs is a whole untested class the AC axis cannot see.
+>
+> **And the 3-slot rule is a FLOOR, not a stopping criterion.** A matrix can be green
+> at ~3 cases/AC while the suite is 10× under-derived — the volume comes from
+> [`test-design.md`](test-design.md) **step 9** (cross-multiply shared classes ×
+> surfaces; exemplar density ~150 cases/US), checked by the Self-review density
+> sanity ([`qc-workflow.md`](qc-workflow.md) §3).
+
+---
+
+## Risk-based priority & regression
+
+**Priority = impact × likelihood.** Impact = blast radius if it breaks (data
+loss, fund loss, auth bypass = high). Likelihood = how often the path runs ×
+how fragile it is. The product sets the priority in the canonical table:
+
+| | High impact | Med impact | Low impact |
+|---|---|---|---|
+| **High likelihood** | Critical | Critical | High |
+| **Med likelihood** | Critical | High | Medium |
+| **Low likelihood** | High | Medium | Low |
+
+**Run-order under time pressure**: Critical first (release-blockers), then High;
+Medium/Low only if time remains. The order is the value of the priority column —
+a suite that can't all run still runs the cases that matter.
+
+**Regression tagging (`RC-`)**: cases that guard the per-release baseline — a
+fixed bug must never return, a cross-story invariant must hold — are tagged
+`RC-<n>` in addition to their TC-ID and collected into the release regression
+set. This is the "undefined regression scope" gap from the backup, closed: the
+`RC-` set *is* the regression scope, run every release.
+
+---
+
+## koni conventions preserved
+
+koni-qc adds rigor on top of the existing koni conventions — it does not discard
+them:
+
+- **Platform-variant columns** — a case that differs by surface keeps the
+  `[extension]` / `[mobile]` / `[webapp]` / `[telegram]` variant tag; one row may
+  fan out per platform (pairwise, see [`test-design.md`](test-design.md)).
+- **L1/L2/L3 sub-case hierarchy** — a parent case may have indented sub-cases for
+  step-level detail; the parent TC-ID owns the matrix entry.
+- **Explicit preconditions** — the Preconditions column is mandatory, never
+  blank, never "logged in" alone — name the exact state.
+- **Issue-tracker links** — a case born from a bug links the issue in its
+  `Covered-by` cell; an `RC-` regression cites the bug it guards.
+- **Native-language steps** — Vietnamese (or other) step text is allowed in
+  internal suites; the canonical docs (koni-docs templates) remain English-only
+  per RULE-13.

--- a/.claude/skills/koni-qc/references/unit-coverage.md
+++ b/.claude/skills/koni-qc/references/unit-coverage.md
@@ -1,0 +1,92 @@
+# unit-coverage — per-function unit tests (the layer below the AC↔TC matrix)
+
+> **Load when**: writing or gating **unit tests** — the per-function/per-branch
+> layer that proves each *function* in isolation, distinct from the AC↔TC matrix
+> ([`traceability.md`](traceability.md)) which proves each *user story's* behaviour.
+> koni-qc **owns this standard** (the per-function rule + the coverage bar);
+> **Dev authors** the unit tests during Execute; **koni-harness enforces** the bar
+> at Self-verify (see the loop's Execute + Self-verify stages). "koni-qc owns the
+> bar; harness runs the gate" — one verb per actor.
+
+**Contents**: [Two layers](#two-layers-unit-vs-actc) ·
+[The per-function rule](#the-per-function-rule) · [TDD cycle](#the-tdd-cycle-red--green--refactor) ·
+[The gate](#the-unit-coverage-gate) · [What to skip](#what-legitimately-needs-no-unit-test) ·
+[Boundary](#composition-boundary)
+
+## Two layers: unit vs AC↔TC
+
+| Layer | Proves | Granularity | Owner | Where |
+|---|---|---|---|---|
+| **Unit** (this file) | each *function/method/branch* in isolation (mocked deps, no I/O) | per function | **koni-qc** owns the bar · **Dev** authors · **harness** enforces | `*.unit.test.ts` (Vitest/Jest/pytest) |
+| **AC↔TC matrix** ([`traceability.md`](traceability.md)) | each *user story's* acceptance behaviour | per US (its ACs) | koni-qc | `test-cases/EPIC-N/US-x.y.md` + `.integration/.e2e/.smoke.spec` |
+
+They are **complementary, not substitutes**: unit tests catch a broken branch a
+story-level e2e would miss; the AC↔TC matrix catches a missing requirement no
+amount of unit testing would surface. A feature needs **both** — unit tests for
+its functions, and AC↔TC coverage for its story.
+
+## The per-function rule
+
+**Every non-trivial function/method gets unit tests that cover, at minimum:**
+
+- the **happy path** (the primary expected input → output);
+- **each branch / decision** (every `if`/`else`, `switch` arm, ternary, guard,
+  early-return) — one test per outcome;
+- **boundary inputs** (empty, zero, min/max, off-by-one — apply BVA from
+  [`test-design.md`](test-design.md));
+- **error / failure paths** (throws, rejects, invalid input handled) — assert the
+  error, not just "no crash".
+
+"Non-trivial" = it has logic: a branch, a computation, a transform, validation,
+or an error path. Name unit tests by **function + behaviour** (`parseRpcUrl →
+rejects a malformed scheme`), not by TC-ID — TC-IDs live at the AC↔TC spec layer,
+units sit below it.
+
+## The TDD cycle (RED → GREEN → REFACTOR)
+
+This is the Execute-stage discipline made concrete, per function **and branch**:
+
+1. **RED** — write the failing unit test first (it must fail for the right reason:
+   run it, see it red).
+2. **GREEN** — write the *minimal* implementation to pass it.
+3. **REFACTOR** — clean up with the test green; add the next branch's test → repeat.
+
+Write the test *before* the implementation — a test written after tends to assert
+"what the code does", not "what it should do".
+
+## The unit-coverage gate
+
+Enforced at the loop's **Self-verify** stage (koni-harness) — a change does not
+advance to Review until:
+
+- **New/changed functions with logic have unit tests** (the per-function rule above)
+  — no new branch ships untested.
+- **Coverage of the changed unit meets the bar** — default **≥80% line-and-branch
+  on new/changed code** (repos may raise it; never silently drop it). Measure with
+  the repo's runner (`vitest run --coverage`, `jest --coverage`, `pytest --cov`);
+  bootstrap the `test:cov` script + the CI workflow + the `passthrough` gate rows per
+  [`test-automation.md`](test-automation.md) §4 (backed by koni-harness
+  [`gate-catalog.md`](../../koni-harness/references/gate-catalog.md)).
+- **All unit tests green** (already the Self-verify tests-green gate).
+
+A repo with zero unit tests for a logic-bearing change fails Self-verify — "build
+is green" is *not* sufficient.
+
+## What legitimately needs no unit test
+
+Don't chase 100% — these are exempt (state the exemption, don't silently skip):
+
+- pure pass-throughs / thin getters / trivial DTO mappers with no logic;
+- generated code, framework glue, config;
+- code whose only behaviour is I/O (that's integration/e2e territory — cover it in
+  the AC↔TC matrix, not here).
+
+If a function *looks* trivial but has a branch, it isn't exempt.
+
+## Composition boundary
+
+koni-qc owns this **standard** (the per-function rule + the coverage bar). It does
+**not** run the tests (the repo's unit runner does, via a koni-harness gate check)
+and does **not** author them (Dev does, during Execute). This mirrors koni-qc
+everywhere: it contributes the *methodology + the gate*, it never reproduces the
+runner or writes the code's tests for it.

--- a/.claude/skills/koni-qc/references/whole-project-qc.md
+++ b/.claude/skills/koni-qc/references/whole-project-qc.md
@@ -1,0 +1,161 @@
+# whole-project-qc — QC an entire repo, not one epic
+
+> **Load when**: QC-ing a **whole existing repo** (not a single epic) — "set up QC
+> for this project", "audit our test coverage", "stand up QA tracking", "is our
+> testing done?". The per-epic lifecycle is [`qc-workflow.md`](qc-workflow.md); **this
+> file is the layer above it** — the QA-tracking backlog, the artifact-location rules,
+> and the Definition-of-Done that stops whole-project QC being declared finished when
+> only *specs* exist. Written from a real deployment (Koni-ERP-02) that ran koni-qc
+> end-to-end yet came out **worse than the reference repo (Senti-Quant)** because these
+> steps were left to operator memory and forgotten.
+
+**Contents**: [The gap](#the-gap) · [1. Stand up the QA tracking epic](#1-stand-up-the-qa-tracking-epic) ·
+[2. Author the strategy + plans](#2-author-the-strategy--plans) ·
+[3. Artifact-location MUSTs](#3-artifact-location-musts) ·
+[4. Execution is required](#4-execution-is-required-not-specs-only) ·
+[5. Definition of Done](#5-definition-of-done-whole-project-qc) ·
+[6. The depth bar — never ship thin stubs](#6-the-depth-bar--never-ship-thin-stubs) ·
+[Ownership](#ownership)
+
+## The gap
+
+Running koni-qc on a repo correctly produces the audit, the `docs/tests/` tree, the
+`test-cases/EPIC-N/` specs + AC↔TC matrices, and automation. But koni-qc's *method*
+does not, on its own, **prescribe standing up the QA-tracking epic**, **author the
+strategy**, **enforce where artifacts land**, **require ≥1 execution**, or **hold every
+authored artifact to a depth bar** before whole-project QC is "done". Left implicit,
+all five get skipped — QC then looks tracked but is a pile of specs with no backlog
+home, no strategy, misplaced plans, zero real run reports, and stub stories. This file
+makes each an explicit step + gate.
+
+## 1. Stand up the QA tracking epic
+
+QC work needs a **home in the backlog and per-epic visibility** — otherwise it hides as
+a couple of stories under a feature epic. Create a dedicated tracking epic (the
+Senti-Quant `EPIC-37 "Test & QA Coverage Tracking"` model):
+
+- **`EPIC-NN "Test & QA Coverage Tracking"`** — a visibility layer that holds **no
+  product code and no source-of-truth spec**; it *tracks* coverage, it doesn't own it.
+  **Numbering**: `NN` = the highest existing app EPIC number **+ 1** (never reuse a
+  retired number, never insert between existing ones) — pick it once, deterministically,
+  so two agents don't diverge.
+- **One coverage story per app epic** — `US-NN.X ↔ EPIC-MM`, 1-to-1 with
+  `<app>/tests/epic/EPIC-MM/` + `test-cases/EPIC-MM.md`. This is what makes coverage
+  visible **per epic** instead of "the project is ~40% tested". A coverage story is
+  **`done`** when its `## Coverage snapshot` target % is met **and** EPIC-MM has ≥1
+  execution report (§4); otherwise it stays **`in-progress`** carrying the current
+  baseline % — never "done" on specs alone.
+- **Infra / process stories** — one story per line that applies. The first three are
+  **mandatory**: foundation (the `docs/tests/` standard + tooling), test-strategy
+  (§2), CI / build gate (§4). The rest **as the audit warrants**: the unit / component /
+  integration / e2e harnesses, execution + reporter, bug-bash cadence, spec
+  remediation, coverage triage.
+- **QA ownership model** (state it in the epic): **dev authors** the spec + the test
+  code; **koni-qc (AI) owns the review side** — the risk / edge / NFR checklist, the
+  AC↔TC matrix, gap-flagging, and fix-requests. The tracking epic records status; the
+  real specs live in `test-cases/`, the real tests in `tests/epic/`.
+
+Each coverage story carries a **`## Coverage snapshot`** table — one row per highest-risk
+US, e.g.:
+
+| US | Current `Covered-by` | Target harness + TC-IDs | Coverage |
+|---|---|---|---|
+| US-4.3 | `— (manual)` | `subscription.integration.spec.ts` · TC-04.SEC-1, TC-04.NEG-2 | 0% → 80% |
+
+## 2. Author the strategy + plans
+
+koni-qc has an "author test-cases" mode but the strategy folder is otherwise left
+empty. Author it — do not scaffold-and-forget:
+
+- **`docs/tests/STRATEGY.md`** (the whole-repo strategy home, per
+  [`test-organization.md`](test-organization.md) §1) — test types + the gate, risk
+  tiers, per-epic priority, automation-wave order, cadence.
+- **Per-epic framing in `test-cases/EPIC-N/index.md`** — that epic's scope,
+  out-of-scope, risk map, priority order, stories-in-scope table (there is **no
+  `test-plan/` folder** — [`test-organization.md`](test-organization.md) §1; the
+  whole-repo strategy stays `STRATEGY.md`).
+
+## 3. Artifact-location MUSTs
+
+Enforce where things land — misplaced artifacts read as "not done" and break tooling:
+
+- **`audits/QC-PLAN-BY-US-<date>.md`** — the per-US risk-tiered coverage plan lives in
+  `docs/tests/audits/`, **never at the tests root**. Same for the coverage audit.
+- **Run reports** at `test-reports/YYYY-MM-DD/EPIC-N/report.md` (auto) /
+  `report-manual.md`, with `auto-coverage.md` at the date level and the latest-state
+  `summary/` rollups — date-first per [`test-organization.md`](test-organization.md)
+  §1 (the epic-first `EPIC-NN/<MMDDYYYY>/` shape is legacy-accepted only); never
+  hand-editing the auto files (the validator is [`test-automation.md`](test-automation.md) §2).
+- **`findings.md`** populated at the tests root; dated one-offs in `audits/`.
+
+## 4. Execution is required (not specs-only)
+
+QC is **not** "done" when the specs are written. koni-qc's Execute stage
+([`qc-workflow.md`](qc-workflow.md) §4) must actually run: at least **one execution
+report** per covered epic — the automated `report.md` from the reporter, and for
+UI-bearing cases the gstack `/design-review` / browser-QA pass with `img/` (vs DESIGN.md
++ the shadcn standard, [`nfr.md`](nfr.md) §UI). Shipping specs-only and calling it
+"tested" is the failure this rule closes.
+
+## 5. Definition of Done (whole-project QC)
+
+Whole-project QC is **NOT done** until every box is true. Add this to the completion
+check and refuse to declare done otherwise:
+
+- [ ] **QA tracking epic** + a coverage story per app epic exist and are in the sprint (§1).
+- [ ] **`STRATEGY.md`** authored + per-epic framing in `test-cases/EPIC-N/index.md` where the epic warrants it (§2).
+- [ ] **`QC-PLAN-BY-US-<date>.md`** + the coverage audit in `audits/`; `findings.md` populated (§3).
+- [ ] **`Covered-by` handles are honest** — every cell is one of the **five fixed
+  forms** ([`traceability.md`](traceability.md)): automated (`<path>::<name>` — and the
+  cited test **exists and passes** under the broken-handle enforcer,
+  [`test-automation.md`](test-automation.md) §2), `PROPOSED:<path>::name`, `— (manual)`,
+  `OPS-DEPLOY:<runbook>`, or `DESIGN-REVIEW:<ref>`. **No phantom automation** (the ERP
+  run had 24 fabricated citations, finding F-8) and no free-text sixth form.
+- [ ] **≥1 execution report per covered epic** at `test-reports/YYYY-MM-DD/EPIC-N/report.md`
+  (§4) — not specs-only. (This is the **Execute/Release** bar: a repo still in
+  authoring-mode — specs written, nothing run yet — is *in-progress*, not *done*; that
+  authoring artifact legitimately defers the execution items per the
+  [`quality-bar.md`](quality-bar.md) author-mode carve-out until it is run.)
+- [ ] **TC-IDs don't collide across layers** — pure-unit vs DB/endpoint cases must not
+  reuse the same ID (the ERP F-12 bug; the reservation rule is [`test-organization.md`](test-organization.md) §3).
+- [ ] **Every authored artifact hits the depth bar** (§6) — no thin stubs. Spot-check 3
+  random outputs **against the §6 section list**; any file missing a required section or
+  not grounded in ≥1 real file/commit citation **fails the batch**.
+
+## 6. The depth bar — never ship thin stubs
+
+**Creating a file is not authoring it.** A story or spec that is a title + a Goal line +
+3-4 bullets looks tracked but carries no decision value to someone reading it in six
+months. The ERP run bulk-generated 21 stories as ~30-line stubs and called them "done";
+they had to be rewritten to 123-140 lines each, grounded in real files and commits.
+
+Hold every artifact koni-qc authors (or asks a generator to author) to this bar:
+
+- **Every story**, in full: `## Goal` (1 para) · `## Background` (2-3 paras — *why* it
+  exists, what the audit surfaced, dependencies) · `## Acceptance criteria` (specific,
+  checkable — not "make it work") · `## Tasks` (`TASK-X.Y.N`, one per AC) ·
+  `## Implementation notes` (done work: *what was actually built* + decisions/traps,
+  cite LESSONS/findings; backlog: the design/approach) · `## Files modified` (real
+  paths) · `## Cross-references`. **Coverage stories** add the `## Coverage snapshot`
+  table (§1).
+- **koni-qc's own outputs** clear the same bar — a `test-cases/EPIC-N/` spec with an empty
+  matrix, an audit with bullet-only findings, or a one-sentence `STRATEGY.md` all fail
+  it exactly as a stub story does (grade with [`quality-bar.md`](quality-bar.md)).
+- **Ground it, don't template it.** For *done* stories read the actual files + `git log`
+  and describe reality; for *backlog* write a real plan with named files + approach. A
+  per-item template filled with the same generic sentence is still a stub.
+- **Bulk generation is fine for the skeleton, not the content.** Script-creating N files
+  is step 1; each must then be authored to depth before the batch is "done". **"Below the
+  bar" is decidable**: a file fails if **any required section above is missing** OR it is
+  **not grounded in ≥1 real file/commit citation**. **koni-qc refuses to close a create
+  step while any artifact fails, and spot-checks 3 random outputs** before declaring
+  completion.
+
+## Ownership
+
+The delegation split is SKILL.md §1 (koni-docs = story/doc bodies · koni-setup = scaffold
+· gstack + repo runner = execution · koni-harness = gate). The **whole-project delta**:
+koni-qc supplies the **QA-epic shape, the Definition-of-Done, and the depth bar** —
+koni-docs still owns each story's *body*. This file is the *whole-project orchestration +
+completion gate* above the per-epic [`qc-workflow.md`](qc-workflow.md); it invokes those
+delegates, never reproduces them.

--- a/.claude/skills/koni-qc/scripts/__tests__/qc-report-test.mjs
+++ b/.claude/skills/koni-qc/scripts/__tests__/qc-report-test.mjs
@@ -1,0 +1,202 @@
+// Self-test for the reference reporter — freezes the parse contract so the two
+// field-found bugs can never silently return (test-automation.md §2):
+//   BUG-1: [A-Z]+ TYPE regex dropping digit-bearing types (E2E, A11Y) — LESSONS §227 (ERP).
+//   BUG-2: `| TC-ID |` header rows counted as cases (over-counted 30) — v1.114.41 (ERP).
+// Plus: broken-handle enforcement (missing + failing + fifth-form + duplicate), orphan
+// run-IDs, header-resolved Covered-by column, counters that SUM to total, ops-deploy
+// class, timing/error capture, density.
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { TC_ID, TC_TOKEN, LIVE_CADENCE, liveCadencePath, scanSpecs, classifyHandle, foldRun, normalizeRunnerJson, buildReport, renderMarkdown } from '../qc-report.mjs';
+
+let PASS = 0, FAIL = 0;
+const ok = (m) => { PASS++; console.log('ok   - ' + m); };
+const no = (m) => { FAIL++; console.log('FAIL - ' + m); };
+const eq = (a, b, m) => (a === b ? ok(m) : no(`${m} (got ${JSON.stringify(a)}, want ${JSON.stringify(b)})`));
+
+// ── BUG-1: the frozen regex accepts digit-bearing TYPEs ──
+eq(TC_ID.test('TC-01.E2E-2'), true, 'regex: E2E accepted (digits in TYPE)');
+eq(TC_ID.test('TC-01.A11Y-1'), true, 'regex: A11Y accepted');
+eq(TC_ID.test('TC-CN.SEC-1'), true, 'regex: domain-prefix epic accepted');
+eq(TC_ID.test('TC-01.WS-5'), true, 'regex: endpoint-prefix TYPE accepted');
+eq(TC_ID.test('TC-ID'), false, 'regex: the literal header word rejected');
+eq(TC_ID.test('TC-01.2E2-1'), false, 'regex: TYPE must start alphabetic');
+
+// ── fixture spec + run ──
+const dir = mkdtempSync(join(tmpdir(), 'qcrep-'));
+writeFileSync(join(dir, 'EPIC-01.md'), `
+# suite
+TC-01.E2E-2:
+  maps_to: { us: US-1.1, fr: FR-1, ac: AC-1 }
+
+| TC-ID | Name | Pri | Covered-by |
+|---|---|---|---|
+| TC-01.E2E-2 | happy flow | High | epic/EPIC-01/a.e2e.spec.ts::TC-01.E2E-2 |
+| TC-01.A11Y-1 | keyboard nav | Med | epic/EPIC-01/a.e2e.spec.ts::TC-01.A11Y-1 |
+| TC-01.NEG-1 | reject bad input | High | epic/EPIC-01/a.integration.spec.ts::TC-01.NEG-1 |
+| TC-01.SEC-1 | cross-tenant blocked | Crit | PROPOSED:epic/EPIC-01/rls.integration.spec.ts::TC-01.SEC-1 |
+| TC-01.FUNC-9 | prod smtp wiring | Low | OPS-DEPLOY:DEPLOY.md#smtp |
+| TC-01.UI-1 | matches DESIGN.md | Med | — (manual) |
+`);
+const runner = JSON.stringify({
+  testResults: [{ assertionResults: [
+    { fullName: 'TC-01.E2E-2 — happy flow', status: 'passed', duration: 12 },
+    { fullName: 'TC-01.E2E-2 — happy flow (retry probe)', status: 'passed', duration: 8 },
+    { fullName: 'TC-01.A11Y-1 — keyboard nav', status: 'passed' },
+    { fullName: 'TC-01.NEG-1 — reject bad input', status: 'failed', failureMessages: ['expected 400, got 200'] },
+    { fullName: 'parseRpcUrl → rejects malformed scheme', status: 'passed' }, // unit test, no TC → ignored
+  ] }],
+});
+
+const rows = scanSpecs(dir);
+// ── BUG-2: header row is NOT a case ──
+eq(rows.length, 6, 'scan: 6 cases (the `| TC-ID |` header row skipped)');
+eq(rows[0].us, 'US-1.1', 'scan: maps_to US captured for density');
+
+// ── classes ──
+eq(classifyHandle('OPS-DEPLOY:DEPLOY.md#smtp'), 'ops-deploy', 'class: ops-deploy form');
+eq(classifyHandle('PROPOSED:x.spec.ts::TC-1'), 'proposed', 'class: proposed form');
+eq(classifyHandle('— (manual)'), 'manual', 'class: manual form');
+eq(classifyHandle('– (manual)'), 'manual', 'class: en-dash manual variant tolerated');
+eq(classifyHandle('a/b.spec.ts::TC-01.E2E-2'), 'automated', 'class: automated form');
+eq(classifyHandle('see wiki'), 'unknown', 'class: free text is NOT a form');
+
+// ── fold + enforce ──
+const folded = foldRun(normalizeRunnerJson(runner));
+eq(folded.get('TC-01.E2E-2').status, 'passed', 'fold: E2E parsed from test name (BUG-1 guarded end-to-end)');
+eq(folded.get('TC-01.E2E-2').ms, 20, 'fold: durations summed per TC');
+eq(folded.get('TC-01.A11Y-1').status, 'passed', 'fold: A11Y parsed');
+eq(folded.get('TC-01.NEG-1').error, 'expected 400, got 200', 'fold: first failure message captured');
+eq(folded.has('TC-01.FUNC-9'), false, 'fold: no phantom entries');
+
+const rep = buildReport(rows, folded);
+eq(rep.counters.total, 6, 'report: total = 6');
+eq(rep.counters.passed, 2, 'report: 2 passed');
+eq(rep.counters['ops-deploy'], 1, 'report: ops-deploy counted in its own column');
+eq(rep.counters.manual, 1, 'report: manual not lumped with ops-deploy');
+// TC-01.NEG-1 cites a FAILING test → broken handle (the enforcer)
+eq(rep.broken.length, 1, 'enforce: failing cited test = 1 broken handle');
+eq(rep.broken[0].id, 'TC-01.NEG-1', 'enforce: the right TC flagged');
+// counters SUM to total (D2 finding: broken must live in a bucket)
+{
+  const c = rep.counters;
+  eq(c.passed + c.failed + c.blocked + c.broken + c['not-written'] + c.manual + c['ops-deploy'], c.total, 'report: status buckets sum to total');
+}
+
+// density telemetry + new columns present
+const md = renderMarkdown(rep, { date: '2026-07-03' });
+eq(md.includes('Density (cases per US'), true, 'render: density table present');
+eq(md.includes('does NOT measure enumeration density'), true, 'render: denominator-honesty line present');
+eq(md.includes('broken handles: 1'), true, 'render: broken count surfaced');
+eq(md.includes('Time (ms)'), true, 'render: timing column present');
+eq(md.includes('expected 400, got 200'), true, 'render: failure detail surfaced');
+
+// duplicate-ID detection (F-12 guard) — flagged broken, NOT double-counted
+const dup = buildReport([...rows, { ...rows[0] }], folded);
+eq(dup.broken.some((b) => b.reason.startsWith('duplicate')), true, 'enforce: duplicate TC-ID flagged');
+eq(dup.counters.passed, 2, 'enforce: duplicate row not double-counted as passed');
+{
+  const c = dup.counters;
+  eq(c.passed + c.failed + c.blocked + c.broken + c['not-written'] + c.manual + c['ops-deploy'], c.total, 'enforce: buckets still sum with a duplicate');
+}
+
+// ── fixture 2: header-resolved Covered-by, missing test, fifth form, orphan ──
+const dir2 = mkdtempSync(join(tmpdir(), 'qcrep2-'));
+writeFileSync(join(dir2, 'EPIC-02.md'), `
+| TC-ID | Name | Covered-by | Notes |
+|---|---|---|---|
+| TC-02.API-1 | create ok | epic/EPIC-02/b.spec.ts::TC-02.API-1 | slow on CI |
+| TC-02.API-2 | cited but never ran | epic/EPIC-02/b.spec.ts::TC-02.API-2 | — |
+| TC-02.API-3 | ad-hoc marker | see wiki | — |
+`);
+const runner2 = JSON.stringify({ tests: [
+  { name: 'TC-02.API-1 — create ok', status: 'passed', durationMs: 5 },
+  { name: 'TC-99.GHOST-1 — not in any spec', status: 'passed' },
+] });
+const rows2 = scanSpecs(dir2);
+eq(rows2[0].coveredBy, 'epic/EPIC-02/b.spec.ts::TC-02.API-1', 'scan: Covered-by resolved from header column, not last cell (Notes after it)');
+const rep2 = buildReport(rows2, foldRun(normalizeRunnerJson(runner2)));
+eq(rep2.counters.passed, 1, 'report2: 1 passed');
+eq(rep2.counters.broken, 2, 'report2: missing-test + fifth-form both counted broken');
+eq(rep2.broken.some((b) => b.reason.includes('did not run')), true, 'enforce: missing cited test flagged');
+eq(rep2.broken.some((b) => b.reason.includes('five fixed forms')), true, 'enforce: out-of-set Covered-by flagged, not laundered to not-written');
+eq(rep2.orphans.length === 1 && rep2.orphans[0] === 'TC-99.GHOST-1', true, 'enforce: orphan run-ID surfaced (spec is the sole authority)');
+{
+  const c = rep2.counters;
+  eq(c.passed + c.failed + c.blocked + c.broken + c['not-written'] + c.manual + c['ops-deploy'], c.total, 'report2: buckets sum to total');
+}
+const md2 = renderMarkdown(rep2, { date: '2026-07-03' });
+eq(md2.includes('ORPHAN TEST IDS'), true, 'render2: orphan section present');
+
+// ── fixture 3: per-US recursive layout, DESIGN-REVIEW form, lane-aware env-pending ──
+import { mkdirSync } from 'node:fs';
+const dir3 = mkdtempSync(join(tmpdir(), 'qcrep3-'));
+mkdirSync(join(dir3, 'EPIC-03'));
+writeFileSync(join(dir3, 'EPIC-03', 'US-3.1.md'), `
+TC-03.API-1:
+  maps_to: { us: US-3.1 }
+
+| TC-ID | Name | Covered-by |
+|---|---|---|
+| TC-03.API-1 | needs live db | tests/epic/EPIC-03/rls.integration.spec.ts::TC-03.API-1 |
+| TC-03.UI-1 | matches DESIGN.md | DESIGN-REVIEW:/dashboard/settings |
+| TC-03.UI-2 | legacy design cell | gstack /design-review (DESIGN.md + shadcn conformance) |
+| TC-03.FUNC-1 | pure logic | tests/epic/EPIC-03/logic.unit.test.ts::TC-03.FUNC-1 |
+`);
+const rows3 = scanSpecs(dir3);
+eq(rows3.length, 4, 'scan3: recursive — per-US file inside EPIC-03/ found');
+eq(classifyHandle('DESIGN-REVIEW:/dashboard/settings'), 'design', 'class: DESIGN-REVIEW form (5th)');
+eq(classifyHandle('gstack /design-review (DESIGN.md + shadcn conformance)'), 'design', 'class: legacy design-review free text reads as form 5');
+eq(LIVE_CADENCE.test('tests/epic/EPIC-03/rls.integration.spec.ts::TC-03.API-1'), true, 'lane: integration cadence detected');
+
+const emptyRun = foldRun({ tests: [] });
+const repUnit = buildReport(rows3, emptyRun, { lane: 'unit' });
+eq(repUnit.counters['env-pending'], 1, 'lane unit: missing live handle folds to env-pending, not broken');
+eq(repUnit.counters.design, 2, 'lane unit: both design cells counted in the design bucket');
+eq(repUnit.counters.broken, 1, 'lane unit: missing NON-live handle (unit cadence) still broken');
+{
+  const c = repUnit.counters;
+  eq(c.passed + c.failed + c.blocked + c.broken + c['env-pending'] + c.design + c['not-written'] + c.manual + c['ops-deploy'], c.total, 'lane unit: buckets sum to total');
+}
+const repFull = buildReport(rows3, emptyRun, { lane: 'full' });
+eq(repFull.counters['env-pending'], 0, 'lane full: nothing hides as env-pending');
+eq(repFull.counters.broken, 2, 'lane full: the live handle IS enforced (missing = broken)');
+const md3 = renderMarkdown(repUnit, { date: '2026-07-03' });
+eq(md3.includes('Covered') && md3.includes('env-pending handles are verified in their own CI lane'), true, 'render3: coverage formula line present');
+
+// ── anti-laundering: classify precedence + lane fail-closed + malformed rows ──
+eq(classifyHandle('PROPOSED:add a design-review pass later'), 'proposed', 'launder: PROPOSED beats design-review free text (stays uncovered)');
+eq(classifyHandle('tests/design-review.spec.ts::TC-9.UI-1'), 'automated', 'launder: a file NAMED design-review stays automated + enforced');
+{
+  // an automated design-review-named handle missing from the run must be BROKEN, not design
+  const rowsL = [{ id: 'TC-9.UI-1', file: 'x.md', us: null, coveredBy: 'tests/design-review.spec.ts::TC-9.UI-1', klass: classifyHandle('tests/design-review.spec.ts::TC-9.UI-1') }];
+  const repL = buildReport(rowsL, foldRun({ tests: [] }), { lane: 'full' });
+  eq(repL.counters.broken, 1, 'launder: missing design-review-named automated handle = broken (enforcer intact)');
+}
+{
+  // lane fails CLOSED at the report level: only 'unit' folds to env-pending
+  const rowsB = [{ id: 'TC-9.API-1', file: 'x.md', us: null, coveredBy: 'a.integration.spec.ts::TC-9.API-1', klass: 'automated' }];
+  const repBogus = buildReport(rowsB, foldRun({ tests: [] }), { lane: 'integration' });
+  eq(repBogus.counters.broken, 1, "lane: unknown lane label ('integration') enforces, never launders to env-pending");
+}
+eq(LIVE_CADENCE.test(liveCadencePath('a.spec.ts::name mentions .integration.spec. here')), false, 'lane: cadence read from the PATH part only, not the test name');
+{
+  // malformed TC-ID first cell is flagged broken, not silently dropped
+  const dirM = mkdtempSync(join(tmpdir(), 'qcrepM-'));
+  writeFileSync(join(dirM, 'EPIC-09.md'), `
+| TC-ID | Name | Covered-by |
+|---|---|---|
+| TC-09.API-1 extra | typo row | a.spec.ts::x |
+| TC-09.API-2 | fine | — (manual) |
+`);
+  const rowsM = scanSpecs(dirM);
+  eq(rowsM.length, 2, 'malformed: typo row still counted (not vanished)');
+  const repM = buildReport(rowsM, foldRun({ tests: [] }));
+  eq(repM.broken.some((b) => b.reason.includes('frozen shape')), true, 'malformed: typo row flagged broken');
+  const c = repM.counters;
+  eq(c.passed + c.failed + c.blocked + c.broken + c['env-pending'] + c.design + c['not-written'] + c.manual + c['ops-deploy'], c.total, 'malformed: buckets still sum');
+}
+
+console.log(`\nqc-report-test: ${PASS} passed, ${FAIL} failed`);
+process.exit(FAIL === 0 ? 0 : 1);

--- a/.claude/skills/koni-qc/scripts/qc-report.mjs
+++ b/.claude/skills/koni-qc/scripts/qc-report.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// qc-report — the reference implementation of the PARSE + CLASSIFY + ENFORCE + DENSITY
+// core of koni-qc's reporter contract (references/test-automation.md §2). Node stdlib
+// only; copy into a repo and adapt. NOT implemented here (adapt-on-copy, per §2–§3):
+// the story write-back, the per-group/failed-by-category/perf rollups of
+// report-quality.md, the collision + non-conformant-path flags, and runner adapters
+// beyond vitest/jest JSON. It exists so the two
+// field-found parse bugs can never silently return:
+//   BUG-1: a TC-TYPE regex of [A-Z]+ drops digit-bearing types (E2E, A11Y).
+//   BUG-2: counting `| TC-ID |` header rows as cases inflates total + manual.
+//
+// Contract enforced (the "broken-handle" rule that makes any 100% trustworthy):
+//   every automated Covered-by handle MUST resolve to an actually-PASSING test in the
+//   run — a cited test that is missing or failing is a BROKEN handle and the exit code
+//   is non-zero. Coverage can then never be faked by editing a spec cell.
+//
+// Usage:
+//   node qc-report.mjs --specs <dir-with-EPIC-*.md> --results <runner.json> [--out report.md]
+//   (results = `vitest run --reporter=json` / `jest --json` output; playwright/pytest
+//    adapters: map their JSON to {tests:[{name,status}]} first.)
+import { readFileSync, readdirSync, writeFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ── the frozen parse contract ──────────────────────────────────────────────────────
+// TYPE = [A-Z][A-Z0-9]* — first char alpha, digits ALLOWED after (E2E, A11Y).
+export const TC_ID = /^TC-[0-9A-Z]+\.[A-Z][A-Z0-9]*-\d+$/;
+export const TC_TOKEN = /TC-[0-9A-Z]+\.[A-Z][A-Z0-9]*-\d+/; // leading-token extraction
+
+export function parseArgs(argv) {
+  const a = { specs: '', results: '', out: '', lane: 'full' };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--specs') a.specs = argv[++i];
+    else if (argv[i] === '--results') a.results = argv[++i];
+    else if (argv[i] === '--out') a.out = argv[++i];
+    else if (argv[i] === '--lane') a.lane = argv[++i]; // 'full' (default: enforce everything) | 'unit' (live handles fold to env-pending)
+  }
+  return a;
+}
+
+// ── SPEC SCAN — every table row whose FIRST CELL is a real TC-ID ───────────────────
+// Any other row (the `| TC-ID |` header, `|---|` separators, prose) is skipped: it is
+// NOT a case and must never count toward total/manual (BUG-2).
+export function scanSpecs(dir) {
+  const rows = [];
+  // recursive: specs live in per-epic dirs (test-cases/EPIC-N/US-x.y.md); legacy flat EPIC-NN.md also matches
+  for (const f of readdirSync(dir, { recursive: true }).map(String)
+    .filter((x) => x.endsWith('.md'))
+    // generated trees are never specs — guard against --specs pointing above test-cases/
+    .filter((x) => !/(^|\/)(test-reports|bug-bash|audits)\//.test(x))) {
+    const file = join(dir, f);
+    let us = null;
+    let covIdx = -1; // Covered-by column index, resolved from the nearest header row
+    for (const line of readFileSync(file, 'utf8').split('\n')) {
+      const mUs = line.match(/\bus:\s*(US-[\d.]+)/); // maps_to yaml (best-effort, for density)
+      if (mUs) us = mUs[1];
+      if (!line.trimStart().startsWith('|')) continue;
+      const cells = line.split('|').map((c) => c.trim());
+      const hIdx = cells.findIndex((c) => /^covered[- ]by$/i.test(c));
+      if (hIdx !== -1) { covIdx = hIdx; continue; } // header row — remember the column, never a case
+      const id = cells[1] || '';
+      if (!TC_ID.test(id)) {
+        // a cell that LOOKS like a TC-ID but fails the frozen shape is an authoring
+        // typo — flag it (a vanishing row is silent data loss); pure header/prose rows skip
+        if (/^TC-/.test(id) && id !== 'TC-ID') rows.push({ id, file: f, us, coveredBy: '', klass: 'malformed' });
+        continue; // header/separator/prose row → skip (BUG-2)
+      }
+      // header-resolved column beats position; fallback = second-to-last cell (trailing | present)
+      const coveredBy = covIdx !== -1 && covIdx < cells.length ? cells[covIdx] : cells.length > 3 ? cells[cells.length - 2] : '';
+      rows.push({ id, file: f, us, coveredBy, klass: classifyHandle(coveredBy) });
+    }
+  }
+  return rows;
+}
+
+// The FIVE fixed Covered-by forms (traceability.md): automated / PROPOSED / manual /
+// OPS-DEPLOY / DESIGN-REVIEW. Legacy free text containing "design-review" reads as form 5.
+export function classifyHandle(cell) {
+  const c = (cell || '').trim();
+  if (/^OPS-DEPLOY:/.test(c)) return 'ops-deploy';
+  if (/^DESIGN-REVIEW:/.test(c)) return 'design';
+  if (/^PROPOSED:/.test(c)) return 'proposed';
+  if (/^[—–-]?\s*\(manual\)/.test(c)) return 'manual'; // dash variants tolerated on read; write the canonical — (manual)
+  if (/::/.test(c)) return 'automated'; // <path>::<name> — checked BEFORE the legacy fallback so a
+  // file merely NAMED design-review.spec.ts stays automated + enforced (no laundering)
+  if (/design-review/i.test(c)) return 'design'; // legacy FREE-TEXT cells only (no fixed form, no ::)
+  return 'unknown';
+}
+
+// ── RUN PARSE — fold runner tests to one status per TC-ID ──────────────────────────
+export function foldRun(results) {
+  const perTc = new Map(); // tcId -> {passed,failed,skipped,ms,error}
+  for (const t of results.tests || []) {
+    const m = String(t.name || '').match(TC_TOKEN); // FIRST TC token in the full name (describe-prefixed names OK)
+    if (!m) continue; // no TC-ID → per-function unit test or orphan test; not a spec case
+    const s = perTc.get(m[0]) || { passed: 0, failed: 0, skipped: 0, ms: 0, error: '' };
+    if (t.status === 'passed') s.passed++;
+    else if (t.status === 'failed') { s.failed++; if (!s.error && t.error) s.error = String(t.error).slice(0, 200); }
+    else s.skipped++;
+    s.ms += Number(t.durationMs) || 0;
+    perTc.set(m[0], s);
+  }
+  const folded = new Map();
+  for (const [id, s] of perTc)
+    folded.set(id, { status: s.failed ? 'failed' : s.skipped ? 'blocked' : 'passed', ms: s.ms, error: s.error });
+  return folded;
+}
+
+// Normalize vitest/jest JSON → {tests:[{name,status}]}
+export function normalizeRunnerJson(raw) {
+  const j = JSON.parse(raw);
+  if (Array.isArray(j.tests)) return j; // already normalized
+  const tests = [];
+  for (const tf of j.testResults || []) {
+    for (const ar of tf.assertionResults || []) {
+      tests.push({ name: ar.fullName || ar.title || '', status: ar.status, durationMs: ar.duration, error: (ar.failureMessages || [])[0] });
+    }
+  }
+  return { tests };
+}
+
+// A handle whose file needs a live env (integration/e2e/smoke cadence) — lane-aware
+// enforcement: in the unit lane a MISSING such test is env-pending, never broken.
+// Cadence is a property of the FILE, so test only the path part (before ::) — a test
+// NAME containing ".integration.spec." must not opt a unit handle into env-pending.
+export const LIVE_CADENCE = /\.(integration|e2e|smoke)\.spec\./;
+export const liveCadencePath = (handle) => String(handle || '').split('::')[0];
+
+// ── the report + the enforcement ────────────────────────────────────────────────────
+export function buildReport(specRows, folded, opts = {}) {
+  const lane = opts.lane || 'full';
+  const rows = [];
+  const broken = [];
+  const counters = { total: 0, passed: 0, failed: 0, blocked: 0, broken: 0, 'env-pending': 0, design: 0, 'not-written': 0, proposed: 0, manual: 0, 'ops-deploy': 0 };
+  const dupSeen = new Map();
+  for (const r of specRows) {
+    counters.total++;
+    if (r.klass === 'malformed') {
+      counters.broken++;
+      broken.push({ id: r.id, reason: 'first cell looks like a TC-ID but violates the frozen shape (authoring typo)' });
+      rows.push({ ...r, status: 'broken', ms: 0, detail: 'malformed TC-ID' });
+      continue;
+    }
+    if (dupSeen.has(r.id)) {
+      // duplicate: flag + count as broken ONLY — never double-count in a status bucket
+      broken.push({ id: r.id, reason: `duplicate TC-ID (also in ${dupSeen.get(r.id)})` });
+      counters.broken++;
+      rows.push({ ...r, status: 'broken', ms: 0, detail: 'duplicate TC-ID' });
+      continue;
+    }
+    dupSeen.set(r.id, r.file);
+    let status, ms = 0, detail = '';
+    if (r.klass === 'automated') {
+      const f = folded.get(r.id);
+      if (!f && lane === 'unit' && LIVE_CADENCE.test(liveCadencePath(r.coveredBy))) {
+        // its own CI lane verifies this handle; here it is covered-pending-env (never broken)
+        status = 'env-pending'; counters['env-pending']++;
+      }
+      else if (!f) { status = 'broken'; counters.broken++; broken.push({ id: r.id, reason: 'Covered-by cites a test that did not run' }); }
+      else {
+        status = f.status; ms = f.ms; detail = f.error;
+        if (status === 'failed') broken.push({ id: r.id, reason: 'Covered-by cites a FAILING test' });
+        counters[status]++;
+      }
+    } else if (r.klass === 'proposed') { status = 'not-written'; counters.proposed++; counters['not-written']++; }
+    else if (r.klass === 'manual') { status = 'manual'; counters.manual++; }
+    else if (r.klass === 'ops-deploy') { status = 'ops-deploy'; counters['ops-deploy']++; }
+    else if (r.klass === 'design') { status = 'design'; counters.design++; }
+    else {
+      // a fifth-form / free-text Covered-by cell is the exact ad-hoc-marker failure the
+      // closed set exists to kill — flag it, never launder it into not-written.
+      status = 'broken'; counters.broken++;
+      broken.push({ id: r.id, reason: `Covered-by is not one of the five fixed forms: "${r.coveredBy}"` });
+    }
+    rows.push({ ...r, status, ms, detail });
+  }
+  // orphan IDs: ran with a TC token the spec doesn't know — flag (spec is the sole authority)
+  const specIds = new Set(specRows.map((r) => r.id));
+  const orphans = [...folded.keys()].filter((id) => !specIds.has(id));
+  // density telemetry: cases per spec file + per US (best-effort)
+  const perFile = {}; const perUs = {};
+  for (const r of specRows) {
+    perFile[r.file] = (perFile[r.file] || 0) + 1;
+    if (r.us) perUs[r.us] = (perUs[r.us] || 0) + 1;
+  }
+  return { rows, broken, orphans, counters, density: { perFile, perUs } };
+}
+
+export function renderMarkdown(rep, meta = {}) {
+  const L = [];
+  const c = rep.counters;
+  const automatedDen = c.total - c.manual - c['ops-deploy'] - c.design;
+  const covered = c.passed + c['env-pending'] + c.design + c['ops-deploy'];
+  L.push(`# QC report — ${meta.date || ''}`.trim(), '');
+  L.push(`**Denominator**: ${c.total} enumerated spec cases (${automatedDen} automatable + ${c.manual} manual + ${c.design} design + ${c['ops-deploy']} ops-deploy). This number measures RESOLUTION of enumerated cases — it does NOT measure enumeration density; see the density table.`, '');
+  L.push(`passed ${c.passed} · failed ${c.failed} · blocked ${c.blocked} · broken ${c.broken} · env-pending ${c['env-pending']} · design ${c.design} · not-written ${c['not-written']} · manual ${c.manual} · ops-deploy ${c['ops-deploy']} · **broken handles: ${rep.broken.length}**`, '');
+  L.push(`**Covered** (= passed + env-pending + design + ops-deploy): ${covered}/${c.total} — env-pending handles are verified in their own CI lane, not this one.`, '');
+  if (rep.broken.length) { L.push('## BROKEN HANDLES (gate red)', ''); for (const b of rep.broken) L.push(`- ${b.id} — ${b.reason}`); L.push(''); }
+  if (rep.orphans && rep.orphans.length) { L.push('## ORPHAN TEST IDS (ran, but unknown to the spec)', ''); for (const o of rep.orphans) L.push(`- ${o}`); L.push(''); }
+  L.push('## Cases', '', '| TC-ID | US | Status | Time (ms) | Covered-by | Failure detail |', '|---|---|---|---|---|---|');
+  for (const r of rep.rows) L.push(`| ${r.id} | ${r.us || '—'} | ${r.status} | ${r.ms || '—'} | ${r.coveredBy} | ${(r.detail || '').replace(/\|/g, '\\|').replace(/\n/g, ' ') || '—'} |`);
+  L.push('', '## Density (cases per US — under-derivation is visible here, not in the % above)', '', '| US | cases |', '|---|---|');
+  for (const [us, n] of Object.entries(rep.density.perUs).sort()) L.push(`| ${us} | ${n} |`);
+  return L.join('\n') + '\n';
+}
+
+async function main() {
+  const a = parseArgs(process.argv.slice(2));
+  if (!a.specs || !a.results) { console.error('usage: qc-report.mjs --specs <dir> --results <runner.json> [--out report.md] [--lane unit|full]'); process.exit(2); }
+  // lane fails CLOSED: only the two known lanes are accepted — a typo ('unnit') or a
+  // job label ('integration') must never silently un-enforce live handles.
+  if (a.lane !== 'full' && a.lane !== 'unit') { console.error(`qc-report: unknown --lane "${a.lane}" (use unit|full)`); process.exit(2); }
+  if (/(^|\/)(test-reports|bug-bash|audits)(\/|$)/.test(a.specs)) { console.error(`qc-report: --specs points at a generated tree, not specs: ${a.specs}`); process.exit(2); }
+  statSync(a.specs); // throws if missing
+  const specRows = scanSpecs(a.specs);
+  const folded = foldRun(normalizeRunnerJson(readFileSync(a.results, 'utf8')));
+  const rep = buildReport(specRows, folded, { lane: a.lane });
+  const md = renderMarkdown(rep, { date: new Date().toISOString().slice(0, 10) });
+  if (a.out) {
+    // path validator (§2 MUST): date-first YYYY-MM-DD/… (canonical), summary/ rollups,
+    // or the legacy epic-first EPIC-NN/MMDDYYYY/ — reject drift before writing.
+    const PATH_OK = [
+      /test-reports\/\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\/auto-coverage\.md$/,
+      /test-reports\/\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\/report(-manual|-notes)?\.md$/, // date-level manual/notes (field shape)
+      /test-reports\/\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\/EPIC-[0-9A-Z]+\/report(-manual|-notes)?\.md$/,
+      /test-reports\/\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\/EPIC-[0-9A-Z]+\/US-[\d.]+\/(api|functional)-test-cases\.md$/,
+      /test-reports\/summary\/(system-test-report|us-coverage-summary)\.md$/,
+      /test-reports\/EPIC-[0-9A-Z]+\/(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])[0-9]{4}\/report(-manual|-notes)?\.md$/, // legacy
+    ];
+    if (/test-reports\//.test(a.out) && !PATH_OK.some((re) => re.test(a.out))) {
+      console.error(`qc-report: --out violates the report-path contract (date-first YYYY-MM-DD/…, summary/, or legacy EPIC-NN/MMDDYYYY/): ${a.out}`);
+      process.exit(2);
+    }
+    writeFileSync(a.out, md);
+  } else process.stdout.write(md);
+  if (rep.broken.length) { console.error(`qc-report: ${rep.broken.length} broken handle(s) — gate red`); process.exit(1); }
+}
+
+// run only when invoked directly (import-safe for the self-test)
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -1,0 +1,44 @@
+---
+id: EPIC-42
+title: "QA Coverage Tracking"
+status: in-progress
+prd_ref: []
+created: 2026-07-16
+updated: 2026-07-16
+---
+
+## Goal
+
+Show QA progress on the board, same as dev progress.
+
+Each dev epic gets **one** QA page here, named `US-42.<epic-number>`. It shows:
+
+- which stories in that epic have been tested
+- how many pass, how many fail
+- how many bugs found
+- a link to the full test result
+
+This epic doesn't ship any product feature. It just puts existing test results where people can see them, instead of leaving them in files nobody opens.
+
+## Why one page per epic
+
+An epic can have 20-30 stories. One QA page per story would be too many files. So one QA page covers a whole epic, with a small table inside listing every story. One place per epic to check "how much is tested."
+
+## What this covers
+
+- **Covers:** the test-status table for each epic, bug counts, link to results.
+- **Doesn't cover:** fixing bugs (tracked on the original story) or writing new tests.
+- **Updated by hand for now** — someone fills this in after each test round. No auto-sync yet.
+
+## Pages
+
+| ID | What | Status |
+|---|---|---|
+| [US-42.1](../stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md) | Stake/unstake screen bugs (#5013) | ready |
+| [US-42.2](../stories/US-42.2-qc-cypress-token-on-base.md) | Cypress token on Base shows correctly (#703) | ready |
+
+More rows get added here as testing starts.
+
+## Not covered here
+
+- This page doesn't replace the test plan — it just shows results, not the plan itself.

--- a/docs/sprints/sprint-2026-W29.md
+++ b/docs/sprints/sprint-2026-W29.md
@@ -1,0 +1,14 @@
+---
+id: sprint-2026-W29
+status: in-progress
+start: 2026-07-13
+end: 2026-07-19
+goal: "QC pass on two open issues: stake/unstake screen bugs (#5013) and Cypress token on Base (#703)"
+---
+
+## Sprint scope
+
+| US | Title | Epic | Pri | Points | Status | Carry | Story file |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| US-42.1 | Stake/unstake screen bugs (#5013) | EPIC-42 | P2 | 3 | ready | new | [link](stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md) |
+| US-42.2 | Cypress token on Base shows correctly (#703) | EPIC-42 | P3 | 3 | ready | new | [link](stories/US-42.2-qc-cypress-token-on-base.md) |

--- a/docs/sprints/stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md
+++ b/docs/sprints/stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md
@@ -1,0 +1,57 @@
+---
+id: US-42.1
+title: "Test — Stake/unstake screen bugs after upgrade (#5013)"
+epic: EPIC-42
+status: ready
+priority: P2
+points: 3
+sprint: sprint-2026-W29
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-07-16
+updated: 2026-07-16
+---
+
+## Goal
+
+Check 2 bugs reported after the version upgrade: the "change validator" confirm screen, and a crash on the unstake screen.
+
+## Background
+
+There's no dev story for this — it's a bug report only ([issue #5013](https://github.com/Koniverse/SubWallet-Extension/issues/5013)), so this page is written straight from the issue text and the attached screenshot/video.
+
+- Bug 1: the confirm screen UI when changing validator (see screenshot in the issue)
+- Bug 2: app crashes when you drag the slider on the unstake screen, then switch account
+
+## Things to check
+
+- [ ] AC-1: The "change validator" confirm screen looks correct — no broken/wrong UI
+- [ ] AC-2: On the unstake screen, dragging the slider then switching account does NOT crash the app
+
+## Steps
+
+- [ ] TASK-42.1.1 — Go to Stake > change validator, check the confirm screen matches the issue's screenshot expectation
+- [ ] TASK-42.1.2 — Go to unstake screen, drag the amount slider, switch account mid-way, confirm no crash
+- [ ] TASK-42.1.3 — Log any bugs found
+
+## Bugs found
+
+_pending — to be filled in after testing_
+
+## Test notes
+
+- **Tested on**: _pending_
+- **Environment**: _pending_
+- **Passed**: _pending_
+
+## Retest
+
+Not started.
+
+## Cross-references
+
+- [Issue #5013](https://github.com/Koniverse/SubWallet-Extension/issues/5013)
+- [US-41.497](US-41.497-extension-some-issues-are-open-when-upgrade-version.md) — tracker record for this issue
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/sprints/stories/US-42.2-qc-cypress-token-on-base.md
+++ b/docs/sprints/stories/US-42.2-qc-cypress-token-on-base.md
@@ -1,0 +1,61 @@
+---
+id: US-42.2
+title: "Test — Cypress (CP) token on Base shows correctly in wallet (#703)"
+epic: EPIC-42
+status: ready
+priority: P3
+points: 3
+sprint: sprint-2026-W29
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-07-16
+updated: 2026-07-16
+---
+
+## Goal
+
+Check that the new Cypress (CP) token on Base shows up correctly in the wallet — right logo, right balance, can send it.
+
+## Background
+
+This request lives in a different repo ([SubWallet-ChainList issue #703](https://github.com/Koniverse/SubWallet-ChainList/issues/703)), not this one — that's where the token gets added to the chain list. This page only covers testing how it looks and works once it shows up here in the wallet.
+
+Token info from the request:
+- Name: Cypress (CP)
+- Chain: Base Mainnet
+- Contract: `0x934ef4bfffdce191ac4bcc351b2fe7892865b440`
+
+## Things to check
+
+- [ ] AC-1: Cypress (CP) shows up in the token list on Base with the correct logo
+- [ ] AC-2: Balance for Cypress shows the correct number (matches a block explorer)
+- [ ] AC-3: Sending Cypress to another address works normally
+
+## Steps
+
+- [ ] TASK-42.2.1 — Confirm the token list update has landed (check chain-list version in use)
+- [ ] TASK-42.2.2 — Check the token shows with correct name/logo on Base
+- [ ] TASK-42.2.3 — Check balance is correct on an account holding this token
+- [ ] TASK-42.2.4 — Send a small amount, confirm it goes through
+- [ ] TASK-42.2.5 — Log any bugs found
+
+## Bugs found
+
+_pending — to be filled in after testing_
+
+## Test notes
+
+- **Tested on**: _pending_
+- **Environment**: _pending_
+- **Passed**: _pending_
+
+## Retest
+
+Not started.
+
+## Cross-references
+
+- [ChainList issue #703](https://github.com/Koniverse/SubWallet-ChainList/issues/703)
+- Epic: [EPIC-42](../epics/EPIC-42.md)


### PR DESCRIPTION
## Summary
- Adds the `koni-qc` skill (test docs / QA workflow) under `.claude/skills/koni-qc/`
- Adds EPIC-42 (QA Coverage Tracking) with its first two test stories:
  - US-42.1 — stake/unstake screen bugs from issue #5013
  - US-42.2 — Cypress (CP) token on Base display check, from ChainList issue #703
- Adds sprint-2026-W29 tracking these two QC stories

## Test plan
- [ ] Run through US-42.1 test steps on the stake/unstake screens
- [ ] Run through US-42.2 test steps for the Cypress token on Base

🤖 Generated with [Claude Code](https://claude.com/claude-code)