### PR TITLE
qc: mark US-42.1 done, add fresh-install/upgrade checks

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -34,7 +34,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 
 | ID | What | Status |
 |---|---|---|
-| [US-42.1](../stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md) | Stake/unstake screen bugs (#5013) | ready |
+| [US-42.1](../stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md) | Stake/unstake screen bugs (#5013) | done |
 | [US-42.2](../stories/US-42.2-qc-cypress-token-on-base.md) | Cypress token on Base shows correctly (#703) | ready |
 
 More rows get added here as testing starts.

--- a/docs/sprints/stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md
+++ b/docs/sprints/stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md
@@ -2,7 +2,7 @@
 id: US-42.1
 title: "Test — Stake/unstake screen bugs after upgrade (#5013)"
 epic: EPIC-42
-status: ready
+status: done
 priority: P2
 points: 3
 sprint: sprint-2026-W29
@@ -27,28 +27,32 @@ There's no dev story for this — it's a bug report only ([issue #5013](https://
 
 ## Things to check
 
-- [ ] AC-1: The "change validator" confirm screen looks correct — no broken/wrong UI
-- [ ] AC-2: On the unstake screen, dragging the slider then switching account does NOT crash the app
+- [x] AC-1: The "change validator" confirm screen looks correct — no broken/wrong UI
+- [x] AC-2: On the unstake screen, dragging the slider then switching account does NOT crash the app
+- [x] AC-3: AC-1 and AC-2 both hold on a **fresh install** (no prior version/data)
+- [x] AC-4: AC-1 and AC-2 both hold on an **upgrade** from a previous version (existing account/data carried over)
 
 ## Steps
 
-- [ ] TASK-42.1.1 — Go to Stake > change validator, check the confirm screen matches the issue's screenshot expectation
-- [ ] TASK-42.1.2 — Go to unstake screen, drag the amount slider, switch account mid-way, confirm no crash
-- [ ] TASK-42.1.3 — Log any bugs found
+- [x] TASK-42.1.1 — Go to Stake > change validator, check the confirm screen matches the issue's screenshot expectation
+- [x] TASK-42.1.2 — Go to unstake screen, drag the amount slider, switch account mid-way, confirm no crash
+- [x] TASK-42.1.3 — Repeat TASK-42.1.1 and TASK-42.1.2 on a fresh install
+- [x] TASK-42.1.4 — Repeat TASK-42.1.1 and TASK-42.1.2 on an upgraded install
+- [x] TASK-42.1.5 — Log any bugs found
 
 ## Bugs found
 
-_pending — to be filled in after testing_
+None. Both issues from #5013 are fixed — checked on fresh install and on upgrade.
 
 ## Test notes
 
-- **Tested on**: _pending_
-- **Environment**: _pending_
-- **Passed**: _pending_
+- **Tested on**: fresh install + upgrade from previous version
+- **Environment**: PR build
+- **Passed**: AC-1, AC-2, AC-3, AC-4 — all pass
 
 ## Retest
 
-Not started.
+Not needed — no bugs found.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.2-qc-cypress-token-on-base.md
+++ b/docs/sprints/stories/US-42.2-qc-cypress-token-on-base.md
@@ -32,6 +32,8 @@ Token info from the request:
 - [ ] AC-1: Cypress (CP) shows up in the token list on Base with the correct logo
 - [ ] AC-2: Balance for Cypress shows the correct number (matches a block explorer)
 - [ ] AC-3: Sending Cypress to another address works normally
+- [ ] AC-4: AC-1 to AC-3 all hold on a **fresh install** (no prior version/data)
+- [ ] AC-5: AC-1 to AC-3 all hold on an **upgrade** from a previous version (existing account/data carried over)
 
 ## Steps
 
@@ -39,7 +41,9 @@ Token info from the request:
 - [ ] TASK-42.2.2 — Check the token shows with correct name/logo on Base
 - [ ] TASK-42.2.3 — Check balance is correct on an account holding this token
 - [ ] TASK-42.2.4 — Send a small amount, confirm it goes through
-- [ ] TASK-42.2.5 — Log any bugs found
+- [ ] TASK-42.2.5 — Repeat TASK-42.2.2 to TASK-42.2.4 on a fresh install
+- [ ] TASK-42.2.6 — Repeat TASK-42.2.2 to TASK-42.2.4 on an upgraded install
+- [ ] TASK-42.2.7 — Log any bugs found
 
 ## Bugs found
 


### PR DESCRIPTION
## Summary
- US-42.1 (stake/unstake screen bugs, #5013): confirmed fixed on fresh install and upgrade (PR build) — status done, no bugs found
- US-42.2 (Cypress token on Base, #703): added fresh-install and upgrade acceptance criteria/steps, still pending test

## Test plan
- [ ] Run through US-42.2 test steps (including fresh install + upgrade) for the Cypress token on Base

🤖 Generated with [Claude Code](https://claude.com/claude-code)