### PR TITLE
qc: close US-42.2 — BUG-42.2-01 fixed, retest passed

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -35,7 +35,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | ID | What | Status |
 |---|---|---|
 | [US-42.1](../stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md) | Stake/unstake screen bugs (#5013) | done |
-| [US-42.2](../stories/US-42.2-qc-cypress-token-on-base.md) | Cypress token on Base shows correctly (#703) | in-progress — 1 bug found |
+| [US-42.2](../stories/US-42.2-qc-cypress-token-on-base.md) | Cypress token on Base shows correctly (#703) | done |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/stories/US-42.2-qc-cypress-token-on-base.md
+++ b/docs/sprints/stories/US-42.2-qc-cypress-token-on-base.md
@@ -2,7 +2,7 @@
 id: US-42.2
 title: "Test — Cypress (CP) token on Base shows correctly in wallet (#703)"
 epic: EPIC-42
-status: in-progress
+status: done
 priority: P3
 points: 3
 sprint: sprint-2026-W29
@@ -31,9 +31,9 @@ Token info from the request:
 
 - [x] AC-1: Cypress (CP) shows up in the token list on Base with the correct logo
 - [x] AC-2: Balance for Cypress shows the correct number (matches a block explorer)
-- [ ] AC-3: Sending Cypress to another address works normally — fail: BUG-42.2-01 (network fee shows 0 ETH on the confirm screen)
-- [x] AC-4: AC-1, AC-2 hold on a **fresh install** (no prior version/data)
-- [ ] AC-5: not tested yet on an **upgrade** from a previous version
+- [x] AC-3: Sending Cypress to another address works normally
+- [x] AC-4: AC-1 to AC-3 all hold on a **fresh install** (no prior version/data)
+- [x] AC-5: AC-1 to AC-3 all hold on an **upgrade** from a previous version (existing account/data carried over)
 
 ## Steps
 
@@ -42,26 +42,26 @@ Token info from the request:
 - [x] TASK-42.2.3 — Check balance is correct on an account holding this token
 - [x] TASK-42.2.4 — Send a small amount, confirm it goes through
 - [x] TASK-42.2.5 — Repeat TASK-42.2.2 to TASK-42.2.4 on a fresh install
-- [ ] TASK-42.2.6 — Repeat TASK-42.2.2 to TASK-42.2.4 on an upgraded install
+- [x] TASK-42.2.6 — Repeat TASK-42.2.2 to TASK-42.2.4 on an upgraded install
 - [x] TASK-42.2.7 — Log any bugs found
 
 ## Bugs found
 
 | ID | Title | Severity | Status |
 |---|---|---|---|
-| BUG-42.2-01 | Network fee shows "0 ETH" on the Cypress transfer confirm screen | P2 | todo |
+| BUG-42.2-01 | Network fee shows "0 ETH" on the Cypress transfer confirm screen | P2 | fixed |
 
 Full details → [report-manual.md](../../tests/test-reports/2026-07-16/report-manual.md)
 
 ## Test notes
 
-- **Tested on**: fresh install only — upgrade not tested yet
+- **Tested on**: fresh install + upgrade from previous version
 - **Environment**: PR build
-- **Passed**: AC-1, AC-2, AC-4 pass. AC-3 fails (BUG-42.2-01). AC-5 not tested.
+- **Passed**: AC-1 to AC-5 — all pass. BUG-42.2-01 fixed and confirmed on retest.
 
 ## Retest
 
-Pending a fix for BUG-42.2-01, then retest AC-3. AC-5 (upgrade) still needs a first pass.
+Done — retested on fresh install and upgrade, network fee now shows correctly. No bugs remaining.
 
 ## Cross-references
 

--- a/docs/tests/test-reports/2026-07-16/report-manual.md
+++ b/docs/tests/test-reports/2026-07-16/report-manual.md
@@ -14,7 +14,7 @@ Not tied to one epic — this covers today's test tasks only.
 | P0 | 0 |
 | P1 | 0 |
 | P2 | 1 |
-| Status | in-progress |
+| Status | done |
 
 ---
 
@@ -31,15 +31,17 @@ None found. Both problems from the issue are fixed:
 
 ## US-42.2 — Cypress (CP) token on Base ([ChainList #703](https://github.com/Koniverse/SubWallet-ChainList/issues/703))
 
-Checked on fresh install. Upgrade not tested yet.
+Checked on fresh install and on an upgraded install.
 
 ### Bugs
 
 | ID | Title | Steps to reproduce | Actual | Expected | Severity | Status | Screenshot |
 |---|---|---|---|---|---|---|---|
-| BUG-42.2-01 | Network fee shows "0 ETH" on the Cypress transfer confirm screen | Fresh install, hold Cypress (CP) on Base, Send → enter amount + recipient → open Transfer confirmation screen | Network fee shows **0 ETH**, with a small non-zero USD estimate underneath (~$0.00069) that doesn't match "0" | Network fee should show the real ETH fee amount, consistent with the USD estimate | P2 | todo | ![](img/2026-07-16_12-04-42.png) |
+| BUG-42.2-01 | Network fee shows "0 ETH" on the Cypress transfer confirm screen | Fresh install, hold Cypress (CP) on Base, Send → enter amount + recipient → open Transfer confirmation screen | Network fee shows **0 ETH**, with a small non-zero USD estimate underneath (~$0.00069) that doesn't match "0" | Network fee should show the real ETH fee amount, consistent with the USD estimate | P2 | fixed | ![](img/2026-07-16_12-04-42.png) |
 
 Amount field (34 CP) displays correctly. Transaction still goes through — this is a display bug on the confirm screen, not a failed transfer.
+
+**Retest (fresh install + upgrade)**: dev fixed the fee display — network fee now shows the correct amount on both install conditions. No bugs remaining.
 
 ---
 
@@ -48,4 +50,4 @@ Amount field (34 CP) displays correctly. Transaction still goes through — this
 | Task | Bugs found | Status |
 |---|---|---|
 | US-42.1 | 0 | done |
-| US-42.2 | 1 (BUG-42.2-01) | in-progress — upgrade + retest still pending |
+| US-42.2 | 1 (BUG-42.2-01, fixed) | done |


### PR DESCRIPTION
## Summary
- US-42.2 (Cypress token on Base, ChainList #703): dev fixed BUG-42.2-01 (network fee showing 0 ETH on the transfer confirm screen)
- Retested AC-1 through AC-5 on both fresh install and upgrade — all pass, no bugs remaining
- US-42.2 and EPIC-42 status moved to done

🤖 Generated with [Claude Code](https://claude.com/claude-code)