### PR TITLE
qc: add US-42.3 (Polkadot Hub EVM chain, #701), all AC pass

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -36,6 +36,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 |---|---|---|
 | [US-42.1](../stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md) | Stake/unstake screen bugs (#5013) | done |
 | [US-42.2](../stories/US-42.2-qc-cypress-token-on-base.md) | Cypress token on Base shows correctly (#703) | done |
+| [US-42.3](../stories/US-42.3-qc-polkadot-hub-evm-chain.md) | Polkadot Hub EVM chain works correctly (#701) | done |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/stories/US-42.3-qc-polkadot-hub-evm-chain.md
+++ b/docs/sprints/stories/US-42.3-qc-polkadot-hub-evm-chain.md
@@ -1,0 +1,68 @@
+---
+id: US-42.3
+title: "Test — Polkadot Hub EVM chain works correctly in wallet (#701)"
+epic: EPIC-42
+status: done
+priority: P3
+points: 3
+sprint: sprint-2026-W29
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-07-16
+updated: 2026-07-16
+---
+
+## Goal
+
+Check that the new Polkadot Hub EVM chain works correctly in the wallet — connects, shows the right name/logo, balance is correct, can send/receive, block explorer link works.
+
+## Background
+
+This request lives in a different repo ([SubWallet-ChainList issue #701](https://github.com/Koniverse/SubWallet-ChainList/issues/701)), not this one — that's where the chain gets added to the chain list. This page only covers testing how it looks and works once it shows up here in the wallet.
+
+Chain info from the request:
+- Name: Polkadot Hub EVM
+- RPC: `https://eth-rpc.polkadot.io/`, `https://services.polkadothub-rpc.com/mainnet/`
+- Block explorer: `https://blockscout.polkadot.io/`
+
+## Things to check
+
+- [x] AC-1: Polkadot Hub EVM shows up in the network list with the correct name and logo
+- [x] AC-2: The wallet connects to the chain and loads without errors
+- [x] AC-3: Balance for the native token shows the correct number (matches the block explorer)
+- [x] AC-4: Sending and receiving on this chain works normally
+- [x] AC-5: The block-explorer link on a transaction opens the correct page on blockscout.polkadot.io
+- [x] AC-6: AC-1 to AC-5 all hold on a **fresh install** (no prior version/data)
+- [x] AC-7: AC-1 to AC-5 all hold on an **upgrade** from a previous version (existing account/data carried over)
+
+## Steps
+
+- [x] TASK-42.3.1 — Confirm the chain list update has landed (check chain-list version in use)
+- [x] TASK-42.3.2 — Add/enable Polkadot Hub EVM, check name/logo and that it connects without errors
+- [x] TASK-42.3.3 — Check balance is correct on an account holding the native token
+- [x] TASK-42.3.4 — Send a small amount, confirm it goes through; check receiving works too
+- [x] TASK-42.3.5 — Open a transaction's block-explorer link, confirm it lands on the right page
+- [x] TASK-42.3.6 — Repeat TASK-42.3.2 to TASK-42.3.5 on a fresh install
+- [x] TASK-42.3.7 — Repeat TASK-42.3.2 to TASK-42.3.5 on an upgraded install
+- [x] TASK-42.3.8 — Log any bugs found
+
+## Bugs found
+
+None. All checks passed.
+
+## Test notes
+
+- **Tested on**: fresh install + upgrade from previous version
+- **Environment**: PR build
+- **Passed**: AC-1 to AC-7 — all pass
+
+## Retest
+
+Not needed — no bugs found.
+
+## Cross-references
+
+- [ChainList issue #701](https://github.com/Koniverse/SubWallet-ChainList/issues/701)
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/tests/test-reports/2026-07-16/report-manual.md
+++ b/docs/tests/test-reports/2026-07-16/report-manual.md
@@ -9,7 +9,7 @@ Not tied to one epic — this covers today's test tasks only.
 | Environment | PR build |
 | Runner | manual (extension) |
 | Build under test | Koniverse/SubWallet-Extension @ koni-qc |
-| Tasks tested | US-42.1, US-42.2 |
+| Tasks tested | US-42.1, US-42.2, US-42.3 |
 | Total bugs found | 1 |
 | P0 | 0 |
 | P1 | 0 |
@@ -43,6 +43,19 @@ Amount field (34 CP) displays correctly. Transaction still goes through — this
 
 **Retest (fresh install + upgrade)**: dev fixed the fee display — network fee now shows the correct amount on both install conditions. No bugs remaining.
 
+## US-42.3 — Polkadot Hub EVM chain ([ChainList #701](https://github.com/Koniverse/SubWallet-ChainList/issues/701))
+
+Checked on fresh install and on an upgraded install.
+
+### Bugs
+
+None found. All checks passed:
+
+- Chain shows up with the correct name and logo, connects without errors.
+- Native token balance matches the block explorer.
+- Sending and receiving both work.
+- Block-explorer link opens the correct page on blockscout.polkadot.io.
+
 ---
 
 ## Summary
@@ -51,3 +64,4 @@ Amount field (34 CP) displays correctly. Transaction still goes through — this
 |---|---|---|
 | US-42.1 | 0 | done |
 | US-42.2 | 1 (BUG-42.2-01, fixed) | done |
+| US-42.3 | 0 | done |


### PR DESCRIPTION
## Summary
- New QC story US-42.3 for ChainList issue #701 (Polkadot Hub EVM chain)
- Tested on fresh install and upgrade — AC-1 through AC-7 all pass, no bugs found
- US-42.3 and EPIC-42 status done

🤖 Generated with [Claude Code](https://claude.com/claude-code)