### PR TITLE
qc: close US-42.4 and US-42.5, all AC pass

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -37,6 +37,8 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.1](../stories/US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md) | Stake/unstake screen bugs (#5013) | done |
 | [US-42.2](../stories/US-42.2-qc-cypress-token-on-base.md) | Cypress token on Base shows correctly (#703) | done |
 | [US-42.3](../stories/US-42.3-qc-polkadot-hub-evm-chain.md) | Polkadot Hub EVM chain works correctly (#701) | done |
+| [US-42.4](../stories/US-42.4-qc-tusdt-on-bittensor.md) | TUSDT token on Bittensor shows correctly (#699) | done |
+| [US-42.5](../stories/US-42.5-qc-myth-xcm-pah-hydration.md) | MYTH XCM between PAH and Hydration retest (#301) | done |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/sprint-2026-W30.md
+++ b/docs/sprints/sprint-2026-W30.md
@@ -1,0 +1,14 @@
+---
+id: sprint-2026-W30
+status: in-progress
+start: 2026-07-20
+end: 2026-07-26
+goal: "QC pass on TUSDT token support on Bittensor (ChainList #699) and regression retest of MYTH XCM PAH<>Hydration (ChainList #301)"
+---
+
+## Sprint scope
+
+| US | Title | Epic | Pri | Points | Status | Carry | Story file |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| US-42.4 | TUSDT token on Bittensor shows correctly (#699) | EPIC-42 | P3 | 3 | ready | new | [link](stories/US-42.4-qc-tusdt-on-bittensor.md) |
+| US-42.5 | MYTH XCM between PAH and Hydration retest (#301) | EPIC-42 | P3 | 3 | ready | new | [link](stories/US-42.5-qc-myth-xcm-pah-hydration.md) |

--- a/docs/sprints/stories/US-42.4-qc-tusdt-on-bittensor.md
+++ b/docs/sprints/stories/US-42.4-qc-tusdt-on-bittensor.md
@@ -1,0 +1,70 @@
+---
+id: US-42.4
+title: "Test — TUSDT token on Bittensor shows correctly in wallet (#699)"
+epic: EPIC-42
+status: done
+priority: P3
+points: 3
+sprint: sprint-2026-W30
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-07-20
+updated: 2026-07-20
+---
+
+## Goal
+
+Check that the new TUSDT token on Bittensor shows up correctly in the wallet — right logo, right balance, can send it.
+
+## Background
+
+This request lives in a different repo ([SubWallet-ChainList issue #699](https://github.com/Koniverse/SubWallet-ChainList/issues/699)), not this one — that's where the token gets added to the chain list. This page only covers testing how it looks and works once it shows up here in the wallet.
+
+Token info from the request:
+- Name: TUSDT
+- Chain: Bittensor
+- Contract: `5GjL2MKErF9ocXZBZZFueoWgf8wAnY1gcgLkDMj2bTsAsg6g`
+- Type: WASM (PSP22) contract token
+
+Related PRs: [ChainList #700](https://github.com/Koniverse/SubWallet-ChainList/pull/700), [Extension #5005](https://github.com/Koniverse/SubWallet-Extension/pull/5005)
+
+## Things to check
+
+- [x] AC-1: TUSDT shows up in the token list on Bittensor with the correct name and logo
+- [x] AC-2: Balance for TUSDT shows the correct number (matches a block explorer)
+- [x] AC-3: Sending TUSDT to another address works normally, including the network fee display on the confirm screen
+- [x] AC-4: Receiving TUSDT works normally
+- [x] AC-5: AC-1 to AC-4 all hold on a **fresh install** (no prior version/data)
+- [x] AC-6: AC-1 to AC-4 all hold on an **upgrade** from a previous version (existing account/data carried over)
+
+## Steps
+
+- [x] TASK-42.4.1 — Confirm the chain-list update has landed (check chain-list version in use)
+- [x] TASK-42.4.2 — Check the token shows with correct name/logo on Bittensor
+- [x] TASK-42.4.3 — Check balance is correct on an account holding this token
+- [x] TASK-42.4.4 — Send a small amount, confirm it goes through and the fee shows correctly on the confirm screen
+- [x] TASK-42.4.5 — Confirm receiving TUSDT works
+- [x] TASK-42.4.6 — Repeat TASK-42.4.2 to TASK-42.4.5 on a fresh install
+- [x] TASK-42.4.7 — Repeat TASK-42.4.2 to TASK-42.4.5 on an upgraded install
+- [x] TASK-42.4.8 — Log any bugs found
+
+## Bugs found
+
+None.
+
+## Test notes
+
+- **Tested on**: PR build
+- **Environment**: PR build
+- **Passed**: Yes
+
+## Retest
+
+N/A — all AC passed on first test.
+
+## Cross-references
+
+- [ChainList issue #699](https://github.com/Koniverse/SubWallet-ChainList/issues/699)
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/sprints/stories/US-42.5-qc-myth-xcm-pah-hydration.md
+++ b/docs/sprints/stories/US-42.5-qc-myth-xcm-pah-hydration.md
@@ -1,0 +1,68 @@
+---
+id: US-42.5
+title: "Retest — XCM support for MYTH token between PAH and Hydration (#301)"
+epic: EPIC-42
+status: done
+priority: P3
+points: 3
+sprint: sprint-2026-W30
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-07-20
+updated: 2026-07-20
+---
+
+## Goal
+
+Retest that XCM transfer of the MYTH token works correctly between Polkadot Asset Hub (PAH) and Hydration — both directions, balance and fee shown correctly.
+
+## Background
+
+This request lives in a different repo ([SubWallet-ChainList issue #301](https://github.com/Koniverse/SubWallet-ChainList/issues/301)), not this one — that's where XCM support for MYTH between PAH and Hydration was added. The issue was closed 2026-02-24. This is a **regression retest** on the current build, not a first-time QC pass.
+
+Request scope from the issue:
+- Token: MYTH
+- Route: Polkadot Asset Hub (PAH) <-> Hydration (both directions)
+
+## Things to check
+
+- [x] AC-1: MYTH shows up with the correct name/logo on both Polkadot Asset Hub and Hydration
+- [x] AC-2: Balance for MYTH shows the correct number on both chains (matches a block explorer)
+- [x] AC-3: XCM transfer of MYTH from PAH to Hydration works, with the correct fee shown on the confirm screen
+- [x] AC-4: XCM transfer of MYTH from Hydration to PAH works, with the correct fee shown on the confirm screen
+- [x] AC-5: Balance updates correctly on both chains after each transfer completes
+- [x] AC-6: AC-1 to AC-5 all hold on a **fresh install** (no prior version/data)
+- [x] AC-7: AC-1 to AC-5 all hold on an **upgrade** from a previous version (existing account/data carried over)
+
+## Steps
+
+- [x] TASK-42.5.1 — Confirm the chain-list version in use still carries MYTH XCM support on this route
+- [x] TASK-42.5.2 — Check MYTH shows with correct name/logo on PAH and on Hydration
+- [x] TASK-42.5.3 — Check balance is correct on an account holding MYTH on both chains
+- [x] TASK-42.5.4 — Send MYTH from PAH to Hydration via XCM, confirm it goes through and fee shows correctly
+- [x] TASK-42.5.5 — Send MYTH from Hydration to PAH via XCM, confirm it goes through and fee shows correctly
+- [x] TASK-42.5.6 — Confirm balances update correctly on both chains after each transfer
+- [x] TASK-42.5.7 — Repeat TASK-42.5.2 to TASK-42.5.6 on a fresh install
+- [x] TASK-42.5.8 — Repeat TASK-42.5.2 to TASK-42.5.6 on an upgraded install
+- [x] TASK-42.5.9 — Log any bugs found
+
+## Bugs found
+
+None.
+
+## Test notes
+
+- **Tested on**: PR build
+- **Environment**: PR build
+- **Passed**: Yes
+
+## Retest
+
+N/A — all AC passed on retest, no regression found.
+
+## Cross-references
+
+- [ChainList issue #301](https://github.com/Koniverse/SubWallet-ChainList/issues/301)
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/tests/test-reports/2026-07-20/report-manual.md
+++ b/docs/tests/test-reports/2026-07-20/report-manual.md
@@ -1,0 +1,54 @@
+# Manual Test Report — 2026-07-20
+
+Not tied to one epic — this covers today's test tasks only.
+
+| Field | Value |
+|---|---|
+| Date | 2026-07-20 |
+| Tester | MaiThuongNinni |
+| Environment | PR build |
+| Runner | manual (extension) |
+| Build under test | Koniverse/SubWallet-Extension @ koni-qc |
+| Tasks tested | US-42.4, US-42.5 |
+| Total bugs found | 0 |
+| P0 | 0 |
+| P1 | 0 |
+| P2 | 0 |
+| Status | done |
+
+---
+
+## US-42.4 — TUSDT token on Bittensor ([ChainList #699](https://github.com/Koniverse/SubWallet-ChainList/issues/699))
+
+Checked on fresh install and on an upgraded install.
+
+### Bugs
+
+None found. All checks passed:
+
+- TUSDT shows up in the token list on Bittensor with the correct name and logo.
+- Balance matches the block explorer.
+- Sending TUSDT works, including correct network fee display on the confirm screen.
+- Receiving TUSDT works.
+
+## US-42.5 — XCM support for MYTH token between PAH and Hydration ([ChainList #301](https://github.com/Koniverse/SubWallet-ChainList/issues/301))
+
+Regression retest. Checked on fresh install and on an upgraded install.
+
+### Bugs
+
+None found. All checks passed:
+
+- MYTH shows up with the correct name/logo on both Polkadot Asset Hub and Hydration.
+- Balance matches the block explorer on both chains.
+- XCM transfer works both directions (PAH to Hydration, Hydration to PAH), with correct fee shown on the confirm screen.
+- Balance updates correctly on both chains after each transfer.
+
+---
+
+## Summary
+
+| Task | Bugs found | Status |
+|---|---|---|
+| US-42.4 | 0 | done |
+| US-42.5 | 0 | done |


### PR DESCRIPTION
## Summary
- US-42.4 — TUSDT token on Bittensor (ChainList #699): tested fresh install + upgrade, all AC pass, no bugs.
- US-42.5 — MYTH XCM PAH <-> Hydration regression retest (ChainList #301): tested fresh install + upgrade, all AC pass, no bugs.
- Adds today's manual test report and updates EPIC-42 coverage table.

## Test plan
- [x] US-42.4 AC-1 to AC-6 verified on fresh install and upgrade
- [x] US-42.5 AC-1 to AC-7 verified on fresh install and upgrade
- [x] No bugs found on either story