### PR TITLE
qc: add US-42.6 release gate for extension v1.3.84

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -39,6 +39,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.3](../stories/US-42.3-qc-polkadot-hub-evm-chain.md) | Polkadot Hub EVM chain works correctly (#701) | done |
 | [US-42.4](../stories/US-42.4-qc-tusdt-on-bittensor.md) | TUSDT token on Bittensor shows correctly (#699) | done |
 | [US-42.5](../stories/US-42.5-qc-myth-xcm-pah-hydration.md) | MYTH XCM between PAH and Hydration retest (#301) | done |
+| [US-42.6](../stories/US-42.6-qc-release-extension-v1-3-84.md) | Release extension v1.3.84 — dev, master, draft, production gate | ready |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -1,0 +1,101 @@
+---
+id: US-42.6
+title: "QC — Release SubWallet Extension v1.3.84"
+epic: EPIC-42
+status: ready
+priority: P2
+points: 8
+sprint: sprint-2026-W30
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-07-21
+updated: 2026-07-21
+---
+
+## Goal
+
+QC the v1.3.84 release end to end, across every build stage from dev merge to production, checking both the release content and that nothing else broke (regression).
+
+## Background
+
+Release content for v1.3.84:
+
+- [Extension] Some issues are open when upgrade version ([#5013](https://github.com/Koniverse/SubWallet-Extension/issues/5013))
+- Update chainlist stable
+- Add XCM support for MYTH token between PAH <> Hydration ([ChainList #301](https://github.com/Koniverse/SubWallet-ChainList/issues/301))
+- Support TUSDT on Bittensor ([ChainList #699](https://github.com/Koniverse/SubWallet-ChainList/issues/699))
+- [Base Mainnet] Add support for Cypress token ([ChainList #703](https://github.com/Koniverse/SubWallet-ChainList/issues/703))
+- Add support for Polkadot Hub EVM ([ChainList #701](https://github.com/Koniverse/SubWallet-ChainList/issues/701))
+
+Each of these items already has its own QC story (US-42.1 to US-42.5) covering the feature-level checks. This story is the **release gate** — it re-verifies the same content lands correctly as it moves through each build stage, plus a regression pass of the app's main functions at each stage.
+
+## Stages
+
+1. **Dev merge** — merge all the issues above into the extension, then regression test on the dev environment.
+2. **Master build** — build from master with the release content above, then regression test on an environment closest to production.
+3. **Draft release** — test the draft release build with the release content above, then regression test on a production-like build in draft form.
+4. **Production** — after publishing, a quick recheck on the live production build.
+
+## Things to check
+
+- [ ] AC-1: All 5 release items (US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM) work correctly after merge into the dev environment
+- [ ] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
+- [ ] AC-3: All 5 release items work correctly on the master build
+- [ ] AC-4: Regression pass on the master build finds no new issues in the app's main functions
+- [ ] AC-5: All 5 release items work correctly on the draft release build
+- [ ] AC-6: Regression pass on the draft release build finds no new issues in the app's main functions
+- [ ] AC-7: Quick recheck on production confirms the release content is live and working, no critical issues
+
+## Regression checklist (main functions)
+
+Run this list at each stage (dev, master, draft, production quick recheck at reduced depth):
+
+- [ ] Create a new account / import an existing account (mnemonic, private key)
+- [ ] Switch between accounts, view balances across chains
+- [ ] Send a native token, confirm it goes through with correct fee display
+- [ ] Receive a token (show/copy address, QR)
+- [ ] Swap tokens (at least one route)
+- [ ] Stake/unstake on at least one network (covers the US-5013 regression area)
+- [ ] XCM transfer between two chains
+- [ ] Connect to a dApp (WalletConnect or injected), sign a message/transaction
+- [ ] Export account (JSON / seed phrase) and remove account
+- [ ] App upgrade path: install previous version, add data, upgrade, confirm data and settings are preserved
+
+## Steps
+
+- [ ] TASK-42.6.1 — Merge US-5013, MYTH XCM, TUSDT, Cypress, and Polkadot Hub EVM into the extension on dev
+- [ ] TASK-42.6.2 — Verify each of the 5 release items on dev (link to US-42.1 to US-42.5 for detailed steps)
+- [ ] TASK-42.6.3 — Run the regression checklist on dev
+- [ ] TASK-42.6.4 — Build from master with the release content, deploy to a near-production environment
+- [ ] TASK-42.6.5 — Verify each of the 5 release items on the master build
+- [ ] TASK-42.6.6 — Run the regression checklist on the master build
+- [ ] TASK-42.6.7 — Test the draft release build (production-like, draft form)
+- [ ] TASK-42.6.8 — Verify each of the 5 release items on the draft build
+- [ ] TASK-42.6.9 — Run the regression checklist on the draft build
+- [ ] TASK-42.6.10 — After publish, do a quick recheck of the release content and core functions on production
+- [ ] TASK-42.6.11 — Log any bugs found, tag with the stage they were found on (dev / master / draft / production)
+
+## Bugs found
+
+Not tested yet.
+
+## Test notes
+
+- **Tested on**: not tested yet
+- **Environment**: dev → master build → draft release → production (all 4 stages)
+- **Passed**: pending
+
+## Retest
+
+N/A — not tested yet.
+
+## Cross-references
+
+- [US-42.1](US-42.1-qc-issue-5013-stake-and-unstake-screen-bugs.md) — stake/unstake screen bugs (#5013)
+- [US-42.2](US-42.2-qc-cypress-token-on-base.md) — Cypress token on Base (#703)
+- [US-42.3](US-42.3-qc-polkadot-hub-evm-chain.md) — Polkadot Hub EVM chain (#701)
+- [US-42.4](US-42.4-qc-tusdt-on-bittensor.md) — TUSDT on Bittensor (#699)
+- [US-42.5](US-42.5-qc-myth-xcm-pah-hydration.md) — MYTH XCM PAH <> Hydration (#301)
+- Epic: [EPIC-42](../epics/EPIC-42.md)


### PR DESCRIPTION
## Summary
- Adds US-42.6 — release gate story for SubWallet Extension v1.3.84.
- Covers 4 build stages: dev merge, master build, draft release, production recheck.
- Each stage verifies the 5 release items (US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM) plus a regression pass of the app's main functions.
- Updates EPIC-42 coverage table with the new story.

## Test plan
- [ ] Not yet executed — story status is `ready`, testing to follow per the 4-stage plan in the story.