### PR TITLE
docs: add QC for recommend validator (#5024)

### DIFF
--- a/docs/sprints/STATUS.md
+++ b/docs/sprints/STATUS.md
@@ -1,8 +1,8 @@
 # Sprint Status
 
 > **AUTO-GENERATED** by `koni-docs status`. Do not hand-edit (RULE-5).
-> Last generated: 2026-07-21 02:38:35 UTC
-> Total stories: 2780
+> Last generated: 2026-07-21 05:21:01 UTC
+> Total stories: 2782
 
 ## 📋 Backlog (292)
 
@@ -301,7 +301,7 @@
 | US-9.10 | NFT display & UI hardening | EPIC-9 | P2 | 5 | — | — |
 | US-9.21 | NFT portfolio management | EPIC-9 | P3 | 1 | — | — |
 
-## 🟢 Ready (16)
+## 🟢 Ready (17)
 
 | ID | Title | Epic | Pri | Points | Sprint | Assignee |
 |---|---|---|---|---|---|---|
@@ -313,16 +313,17 @@
 | US-30.56 | Integrate with AirGap Vault for QR signer | EPIC-30 | P3 | 1 | sprint-2026-W28 | PDTnhah |
 | US-31.25 | Extension - Show incorrect fee when swap | EPIC-31 | P3 | 1 | sprint-2026-W28 | tunghp2002 |
 | US-31.79 | Extension - Update content in-app for Swap (Round 2) | EPIC-31 | P3 | 1 | sprint-2026-W28 | Quangdm-cdm |
-| US-32.372 | Add recommend validator for native and subnet staking | EPIC-32 | P3 | 1 | sprint-2026-W30 | tunghp2002 |
 | US-39.13 | Extension - Check bug spam notification | EPIC-39 | P3 | 1 | sprint-2026-W28 | bluezdot |
 | US-41.248 | Clean up i18n data and re-apply i18n | EPIC-41 | P3 | 1 | sprint-2026-W28 | frenkie-ng |
 | US-41.288 | Check for issues related to middleware services | EPIC-41 | P3 | 1 | sprint-2026-W28 | bluezdot |
 | US-41.418 | Support DeDot | EPIC-41 | P3 | 1 | sprint-2026-W28 | bluezdot |
 | US-41.423 | Implement Light-client related issues | EPIC-41 | P3 | 1 | sprint-2026-W28 | — |
 | US-41.429 | Other improvements | EPIC-41 | P3 | 1 | sprint-2026-W28 | — |
+| US-42.6 | QC — Release SubWallet Extension v1.3.84 | EPIC-42 | P2 | 8 | sprint-2026-W30 | MaiThuongNinni |
+| US-42.7 | QC — Add recommend validator for native and subnet staking (#5024) | EPIC-42 | P2 | 8 | sprint-2026-W30 | — |
 | US-8.12 | Fee/BigInt & gas-estimation hardening | EPIC-8 | P1 | 5 | sprint-2026-W28 | bluezdot |
 
-## 🟡 In Progress (29)
+## 🟡 In Progress (30)
 
 | ID | Title | Epic | Pri | Points | Sprint | Assignee |
 |---|---|---|---|---|---|---|
@@ -340,6 +341,7 @@
 | US-31.102 | Extension - Support Hollar (Hydration) token in list token to paid fee | EPIC-31 | P3 | 1 | sprint-2026-W28 | bluezdot |
 | US-31.105 | Improve the algorithm to support more swap path | EPIC-31 | P3 | 1 | sprint-2026-W28 | bluezdot |
 | US-32.260 | Recheck and update cancel unstake logic for amplitude, krest native staking | EPIC-32 | P3 | 1 | sprint-2026-W28 | bluezdot |
+| US-32.372 | Add recommend validator for native and subnet staking | EPIC-32 | P3 | 1 | sprint-2026-W30 | tunghp2002 |
 | US-33.33 | Add support for USDT on more chains and update param for XCM on Astar | EPIC-33 | P3 | 1 | sprint-2026-W28 | PDTnhah |
 | US-33.85 | Review and add more XCM Channels | EPIC-33 | P3 | 1 | sprint-2026-W28 | saltict |
 | US-33.86 | Support bridge without XCM | EPIC-33 | P3 | 1 | sprint-2026-W28 | — |
@@ -2823,11 +2825,11 @@ _No stories_
 ## Summary
 
 - 📋 **Backlog**: 292
-- 🟢 **Ready**: 16
-- 🟡 **In Progress**: 29
+- 🟢 **Ready**: 17
+- 🟡 **In Progress**: 30
 - 👀 **Review**: 12
 - ✅ **Done**: 2225
 - 🚫 **Blocked**: 0
 - 🗑️ **Deprecated**: 206
 
-⚠️  **WIP limit exceeded**: 29 stories in-progress (limit: 3).
+⚠️  **WIP limit exceeded**: 30 stories in-progress (limit: 3).

--- a/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
+++ b/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
@@ -1,0 +1,68 @@
+---
+id: US-42.7
+title: "QC — Add recommend validator for native and subnet staking (#5024)"
+epic: EPIC-42
+status: ready
+priority: P2
+points: 5
+sprint: sprint-2026-W30
+version_shipped:
+prd_ref: []
+assignee: 
+commit:
+created: 2026-07-21
+updated: 2026-07-21
+---
+
+## Goal
+
+Verify the "Recommend validator" feature for native staking and subnet staking across all 3 platforms (Extension, Web App, Mobile). Ensure the recommended validators are populated correctly and the selection works seamlessly in both fresh install and upgrade scenarios.
+
+## Background
+
+This QC story covers the implementation of [issue #5024](https://github.com/Koniverse/SubWallet-Extension/issues/5024): Add recommend validator for native and subnet staking.
+The scope requires full validation across three platforms: Extension, Webapp, and Mobile, including data migration/persistence during version upgrades.
+
+## Acceptance criteria
+
+- [ ] **AC-1**: When user initiates native staking, the system provides a "Recommended" validator option or automatically selects the best validators.
+- [ ] **AC-2**: When user initiates subnet staking, the system correctly suggests recommended subnet validators.
+- [ ] **AC-3**: The recommended validators meet expected criteria (e.g., active status, identity, reasonable commission).
+- [ ] **AC-4**: The user can choose to override the recommended validators and select their own manually.
+- [ ] **AC-5**: AC-1 to AC-4 work smoothly on the Extension without UI glitches or crashes.
+- [ ] **AC-6**: AC-1 to AC-4 work smoothly on the Web App without UI glitches or crashes.
+- [ ] **AC-7**: AC-1 to AC-4 work smoothly on the Mobile App without UI glitches or crashes.
+- [ ] **AC-8**: The feature behaves correctly on a fresh install across all platforms.
+- [ ] **AC-9**: The feature behaves correctly on a version upgrade across all platforms (existing accounts and data are preserved).
+
+## Tasks
+
+- [ ] TASK-42.7.1 — Extension: Test Native & Subnet staking recommended flow on a fresh install.
+- [ ] TASK-42.7.2 — Extension: Test Native & Subnet staking recommended flow on an upgraded version.
+- [ ] TASK-42.7.3 — Web App: Test Native & Subnet staking recommended flow on a fresh install.
+- [ ] TASK-42.7.4 — Web App: Test Native & Subnet staking recommended flow on an upgraded version.
+- [ ] TASK-42.7.5 — Mobile: Test Native & Subnet staking recommended flow on a fresh install.
+- [ ] TASK-42.7.6 — Mobile: Test Native & Subnet staking recommended flow on an upgraded version.
+- [ ] TASK-42.7.7 — Verify user can unselect recommended validators and manually pick others on all platforms.
+- [ ] TASK-42.7.8 — Log any bugs found.
+
+## Bugs found
+
+| ID | Title | Severity | Status |
+|---|---|---|---|
+| — | — | — | — |
+
+## Test notes
+
+- **Tested on**: Extension (Chrome), Web App, Mobile (iOS/Android)
+- **Environment**: PR build / Staging
+- **AC passed**: 0 / 9
+
+## Retest
+
+Not started.
+
+## Cross-references
+
+- [Issue #5024](https://github.com/Koniverse/SubWallet-Extension/issues/5024)
+- Epic: [EPIC-42](../epics/EPIC-42.md)


### PR DESCRIPTION
## Goal
Add initial QC story for EPIC-42 to verify the "Recommend validator" feature for native and subnet staking (#5024).

## Details
1. **Added `US-42.7-qc-recommend-validator-native-subnet-staking.md`**:
   - Covers the testing flow for checking recommended validators on both Native Staking (Polkadot/Kusama) and Subnet Staking (Bittensor).
   - Establishes a comprehensive test matrix across 3 platforms (Extension, Web App, Mobile) for both Fresh Install and Version Upgrade scenarios.
   - Maps to Dev story / Issue: `#5024` (Add recommend validator for native and subnet staking).

2. **Updated `STATUS.md`**:
   - Auto-regenerated kanban board status to include the new `US-42.7` QC story.

## Notes
- Points have been scaled to `5` to account for the multi-platform (Extension, Web, Mobile) and installation state (Fresh vs Upgrade) testing complexity.
- The Acceptance Criteria (AC) are structured as a direct checklist to ensure full matrix coverage during manual QA execution.
