### PR TITLE
docs: QC for recommend validator staking (#5024) + release v1.3.84 update

### DIFF
--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -28,8 +28,9 @@ Release content for v1.3.84:
 - Support TUSDT on Bittensor ([ChainList #699](https://github.com/Koniverse/SubWallet-ChainList/issues/699))
 - [Base Mainnet] Add support for Cypress token ([ChainList #703](https://github.com/Koniverse/SubWallet-ChainList/issues/703))
 - Add support for Polkadot Hub EVM ([ChainList #701](https://github.com/Koniverse/SubWallet-ChainList/issues/701))
+- [Extension] Add recommend validator for native and subnet staking ([#5024](https://github.com/Koniverse/SubWallet-Extension/issues/5024))
 
-Each of these items already has its own QC story (US-42.1 to US-42.5) covering the feature-level checks. This story is the **release gate** — it re-verifies the same content lands correctly as it moves through each build stage, plus a regression pass of the app's main functions at each stage.
+Each of these items already has its own QC story (US-42.1 to US-42.5, US-42.7) covering the feature-level checks. This story is the **release gate** — it re-verifies the same content lands correctly as it moves through each build stage, plus a regression pass of the app's main functions at each stage.
 
 ## Stages
 
@@ -40,11 +41,11 @@ Each of these items already has its own QC story (US-42.1 to US-42.5) covering t
 
 ## Things to check
 
-- [ ] AC-1: All 5 release items (US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM) work correctly after merge into the dev environment
+- [ ] AC-1: All 6 release items (US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM, recommend validator #5024) work correctly after merge into the dev environment
 - [ ] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
-- [ ] AC-3: All 5 release items work correctly on the master build
+- [ ] AC-3: All 6 release items work correctly on the master build
 - [ ] AC-4: Regression pass on the master build finds no new issues in the app's main functions
-- [ ] AC-5: All 5 release items work correctly on the draft release build
+- [ ] AC-5: All 6 release items work correctly on the draft release build
 - [ ] AC-6: Regression pass on the draft release build finds no new issues in the app's main functions
 - [ ] AC-7: Quick recheck on production confirms the release content is live and working, no critical issues
 
@@ -58,6 +59,7 @@ Run this list at each stage (dev, master, draft, production quick recheck at red
 - [ ] Receive a token (show/copy address, QR)
 - [ ] Swap tokens (at least one route)
 - [ ] Stake/unstake on at least one network (covers the US-5013 regression area)
+- [ ] Start a native/subnet staking flow and confirm the recommended validator suggestion appears and can be overridden (covers the #5024 regression area)
 - [ ] XCM transfer between two chains
 - [ ] Connect to a dApp (WalletConnect or injected), sign a message/transaction
 - [ ] Export account (JSON / seed phrase) and remove account
@@ -65,14 +67,14 @@ Run this list at each stage (dev, master, draft, production quick recheck at red
 
 ## Steps
 
-- [ ] TASK-42.6.1 — Merge US-5013, MYTH XCM, TUSDT, Cypress, and Polkadot Hub EVM into the extension on dev
-- [ ] TASK-42.6.2 — Verify each of the 5 release items on dev (link to US-42.1 to US-42.5 for detailed steps)
+- [ ] TASK-42.6.1 — Merge US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM, and recommend validator (#5024) into the extension on dev
+- [ ] TASK-42.6.2 — Verify each of the 6 release items on dev (link to US-42.1 to US-42.5, US-42.7 for detailed steps)
 - [ ] TASK-42.6.3 — Run the regression checklist on dev
 - [ ] TASK-42.6.4 — Build from master with the release content, deploy to a near-production environment
-- [ ] TASK-42.6.5 — Verify each of the 5 release items on the master build
+- [ ] TASK-42.6.5 — Verify each of the 6 release items on the master build
 - [ ] TASK-42.6.6 — Run the regression checklist on the master build
 - [ ] TASK-42.6.7 — Test the draft release build (production-like, draft form)
-- [ ] TASK-42.6.8 — Verify each of the 5 release items on the draft build
+- [ ] TASK-42.6.8 — Verify each of the 6 release items on the draft build
 - [ ] TASK-42.6.9 — Run the regression checklist on the draft build
 - [ ] TASK-42.6.10 — After publish, do a quick recheck of the release content and core functions on production
 - [ ] TASK-42.6.11 — Log any bugs found, tag with the stage they were found on (dev / master / draft / production)
@@ -98,4 +100,5 @@ N/A — not tested yet.
 - [US-42.3](US-42.3-qc-polkadot-hub-evm-chain.md) — Polkadot Hub EVM chain (#701)
 - [US-42.4](US-42.4-qc-tusdt-on-bittensor.md) — TUSDT on Bittensor (#699)
 - [US-42.5](US-42.5-qc-myth-xcm-pah-hydration.md) — MYTH XCM PAH <> Hydration (#301)
+- [US-42.7](US-42.7-qc-recommend-validator-native-subnet-staking.md) — recommend validator for native/subnet staking (#5024)
 - Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
+++ b/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
@@ -1,8 +1,8 @@
 ---
 id: US-42.7
-title: "QC — Add recommend validator for native and subnet staking (#5024)"
+title: "QC — Add recommend validator for native and subnet staking on Extension (#5024)"
 epic: EPIC-42
-status: ready
+status: in-progress
 priority: P2
 points: 5
 sprint: sprint-2026-W30
@@ -16,35 +16,29 @@ updated: 2026-07-21
 
 ## Goal
 
-Verify the "Recommend validator" feature for native staking and subnet staking across all 3 platforms (Extension, Web App, Mobile). Ensure the recommended validators are populated correctly and the selection works seamlessly in both fresh install and upgrade scenarios.
+Verify the "Recommend validator" feature for native staking and subnet staking on the **Extension**. Ensure the recommended validators are populated correctly and the selection works seamlessly in both fresh install and upgrade scenarios.
 
 ## Background
 
 This QC story covers the implementation of [issue #5024](https://github.com/Koniverse/SubWallet-Extension/issues/5024): Add recommend validator for native and subnet staking.
-The scope requires full validation across three platforms: Extension, Webapp, and Mobile, including data migration/persistence during version upgrades.
+This story covers the **Extension only**. Web App and Mobile ship on their own release schedules, so a separate story will be created for them when that testing starts — keeping platforms in one story would tie their release gates together when they shouldn't be.
 
 ## Acceptance criteria
 
-- [ ] **AC-1**: When user initiates native staking, the system provides a "Recommended" validator option or automatically selects the best validators.
-- [ ] **AC-2**: When user initiates subnet staking, the system correctly suggests recommended subnet validators.
-- [ ] **AC-3**: The recommended validators meet expected criteria (e.g., active status, identity, reasonable commission).
-- [ ] **AC-4**: The user can choose to override the recommended validators and select their own manually.
-- [ ] **AC-5**: AC-1 to AC-4 work smoothly on the Extension without UI glitches or crashes.
-- [ ] **AC-6**: AC-1 to AC-4 work smoothly on the Web App without UI glitches or crashes.
-- [ ] **AC-7**: AC-1 to AC-4 work smoothly on the Mobile App without UI glitches or crashes.
-- [ ] **AC-8**: The feature behaves correctly on a fresh install across all platforms.
-- [ ] **AC-9**: The feature behaves correctly on a version upgrade across all platforms (existing accounts and data are preserved).
+- [x] **AC-1**: When user initiates native staking, the system provides a "Recommended" validator option or automatically selects the best validators.
+- [x] **AC-2**: When user initiates subnet staking, the system correctly suggests recommended subnet validators.
+- [x] **AC-3**: The recommended validators meet expected criteria (e.g., active status, identity, reasonable commission).
+- [x] **AC-4**: The user can choose to override the recommended validators and select their own manually.
+- [x] **AC-5**: AC-1 to AC-4 work smoothly on the Extension without UI glitches or crashes.
+- [x] **AC-6**: The feature behaves correctly on a fresh install of the Extension.
+- [x] **AC-7**: The feature behaves correctly on a version upgrade of the Extension (existing accounts and data are preserved).
 
 ## Tasks
 
-- [ ] TASK-42.7.1 — Extension: Test Native & Subnet staking recommended flow on a fresh install.
-- [ ] TASK-42.7.2 — Extension: Test Native & Subnet staking recommended flow on an upgraded version.
-- [ ] TASK-42.7.3 — Web App: Test Native & Subnet staking recommended flow on a fresh install.
-- [ ] TASK-42.7.4 — Web App: Test Native & Subnet staking recommended flow on an upgraded version.
-- [ ] TASK-42.7.5 — Mobile: Test Native & Subnet staking recommended flow on a fresh install.
-- [ ] TASK-42.7.6 — Mobile: Test Native & Subnet staking recommended flow on an upgraded version.
-- [ ] TASK-42.7.7 — Verify user can unselect recommended validators and manually pick others on all platforms.
-- [ ] TASK-42.7.8 — Log any bugs found.
+- [x] TASK-42.7.1 — Test Native & Subnet staking recommended flow on a fresh install.
+- [x] TASK-42.7.2 — Test Native & Subnet staking recommended flow on an upgraded version.
+- [x] TASK-42.7.3 — Verify user can unselect recommended validators and manually pick others.
+- [x] TASK-42.7.4 — Log any bugs found.
 
 ## Bugs found
 
@@ -52,15 +46,17 @@ The scope requires full validation across three platforms: Extension, Webapp, an
 |---|---|---|---|
 | — | — | — | — |
 
+None found.
+
 ## Test notes
 
-- **Tested on**: Extension (Chrome), Web App, Mobile (iOS/Android)
+- **Tested on**: Extension (Chrome) — pass.
 - **Environment**: PR build / Staging
-- **AC passed**: 0 / 9
+- **AC passed**: 7 / 7
 
 ## Retest
 
-Not started.
+N/A — no bugs found.
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary
- Add QC story US-42.7 for "Recommend validator" (native/subnet staking) on Extension, scope explicitly Extension-only (Web App/Mobile to be tracked in a separate story later).
- Fold issue #5024 into the US-42.6 release gate for v1.3.84 (background, AC, regression checklist, tasks, cross-references).

## Test plan
- [ ] Docs-only change, no code affected