### PR TITLE
docs: add US-42.9 QC for webapp release v1.3.56-0 (#5024)

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -40,6 +40,8 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.4](../stories/US-42.4-qc-tusdt-on-bittensor.md) | TUSDT token on Bittensor shows correctly (#699) | done |
 | [US-42.5](../stories/US-42.5-qc-myth-xcm-pah-hydration.md) | MYTH XCM between PAH and Hydration retest (#301) | done |
 | [US-42.6](../stories/US-42.6-qc-release-extension-v1-3-84.md) | Release extension v1.3.84 — dev, master, draft, production gate | ready |
+| [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — Extension (#5024) | in-progress |
+| [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | ready |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
+++ b/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
@@ -1,0 +1,82 @@
+---
+id: US-42.9
+title: "QC — Release SubWallet Web App v1.3.56-0 (build 1356-0014)"
+epic: EPIC-42
+status: ready
+priority: P2
+points: 5
+sprint: sprint-2026-W30
+version_shipped:
+prd_ref: []
+assignee: 
+commit:
+created: 2026-07-22
+updated: 2026-07-22
+---
+
+## Goal
+
+QC the Web App v1.3.56-0 (build 1356-0014) release end to end: merge into dev, check the feature works, run regression — then repeat the same checks on production after it ships.
+
+## Background
+
+Release content for v1.3.56-0 (1356-0014):
+
+- [WebApp] Add recommend validator for native and subnet staking ([#5024](https://github.com/Koniverse/SubWallet-Extension/issues/5024))
+
+This is the Web App counterpart to the Extension release of the same feature ([US-42.7](US-42.7-qc-recommend-validator-native-subnet-staking.md)). Web App ships on its own schedule, separate from Extension and Mobile, so it gets its own release gate here.
+
+## Stages
+
+1. **Dev** — merge the PR into the web app dev environment, verify the recommend validator feature works as expected, then run a regression pass.
+2. **Production** — after the release ships to production, verify the recommend validator feature works as expected, then run a regression pass.
+
+## Things to check
+
+- [ ] AC-1: Recommend validator (#5024) merged into web app dev and works correctly (native + subnet staking)
+- [ ] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
+- [ ] AC-3: Recommend validator (#5024) works correctly on production
+- [ ] AC-4: Regression pass on production finds no new issues in the app's main functions
+
+## Regression checklist (main functions)
+
+Run this list at each stage (dev, production):
+
+- [ ] Create a new account / import an existing account (mnemonic, private key)
+- [ ] Switch between accounts, view balances across chains
+- [ ] Send a native token, confirm it goes through with correct fee display
+- [ ] Receive a token (show/copy address, QR)
+- [ ] Swap tokens (at least one route)
+- [ ] Stake/unstake on at least one network
+- [ ] XCM transfer between two chains
+- [ ] Connect to a dApp (WalletConnect or injected), sign a message/transaction
+- [ ] Export account (JSON / seed phrase) and remove account
+
+## Steps
+
+- [ ] TASK-42.9.1 — Merge PR for recommend validator (#5024) into web app dev
+- [ ] TASK-42.9.2 — Verify recommend validator feature works on dev (native + subnet staking, override works) — link to US-42.7 for detailed steps
+- [ ] TASK-42.9.3 — Run the regression checklist on dev
+- [ ] TASK-42.9.4 — After release ships to production, verify recommend validator feature works on production
+- [ ] TASK-42.9.5 — Run the regression checklist on production
+- [ ] TASK-42.9.6 — Log any bugs found, tag with the stage they were found on (dev / production)
+
+## Bugs found
+
+Not tested yet.
+
+## Test notes
+
+- **Tested on**: not tested yet
+- **Environment**: dev → production
+- **Passed**: pending
+
+## Retest
+
+N/A — not tested yet.
+
+## Cross-references
+
+- [Issue #5024](https://github.com/Koniverse/SubWallet-Extension/issues/5024)
+- [US-42.7](US-42.7-qc-recommend-validator-native-subnet-staking.md) — same feature QC on Extension
+- Epic: [EPIC-42](../epics/EPIC-42.md)


### PR DESCRIPTION
## Summary
- Add QC story US-42.9 for Web App release v1.3.56-0 (build 1356-0014) — recommend validator for native/subnet staking (#5024), covering Dev merge + regression and Production + regression stages.
- Update EPIC-42 QA tracking page to list US-42.7 and US-42.9.

## Test plan
- [ ] Docs-only change, no code affected