### PR TITLE
docs: update US-42.6/US-42.7 QC progress and commit fields

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -40,7 +40,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.4](../stories/US-42.4-qc-tusdt-on-bittensor.md) | TUSDT token on Bittensor shows correctly (#699) | done |
 | [US-42.5](../stories/US-42.5-qc-myth-xcm-pah-hydration.md) | MYTH XCM between PAH and Hydration retest (#301) | done |
 | [US-42.6](../stories/US-42.6-qc-release-extension-v1-3-84.md) | Release extension v1.3.84 — dev, master, draft, production gate | ready |
-| [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — Extension (#5024) | in-progress |
+| [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — PR test, all 3 platforms (#5024) | in-progress |
 | [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | ready |
 
 More rows get added here as testing starts.

--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: MaiThuongNinni
-commit:
+commit: a11851b32b, 1a782ee974, 962cc44f39
 created: 2026-07-21
 updated: 2026-07-21
 ---

--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -41,8 +41,8 @@ Each of these items already has its own QC story (US-42.1 to US-42.5, US-42.7) c
 
 ## Things to check
 
-- [ ] AC-1: All 6 release items (US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM, recommend validator #5024) work correctly after merge into the dev environment
-- [ ] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
+- [x] AC-1: All 6 release items (US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM, recommend validator #5024) work correctly after merge into the dev environment
+- [x] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
 - [ ] AC-3: All 6 release items work correctly on the master build
 - [ ] AC-4: Regression pass on the master build finds no new issues in the app's main functions
 - [ ] AC-5: All 6 release items work correctly on the draft release build
@@ -67,9 +67,9 @@ Run this list at each stage (dev, master, draft, production quick recheck at red
 
 ## Steps
 
-- [ ] TASK-42.6.1 — Merge US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM, and recommend validator (#5024) into the extension on dev
-- [ ] TASK-42.6.2 — Verify each of the 6 release items on dev (link to US-42.1 to US-42.5, US-42.7 for detailed steps)
-- [ ] TASK-42.6.3 — Run the regression checklist on dev
+- [x] TASK-42.6.1 — Merge US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM, and recommend validator (#5024) into the extension on dev
+- [x] TASK-42.6.2 — Verify each of the 6 release items on dev (link to US-42.1 to US-42.5, US-42.7 for detailed steps)
+- [x] TASK-42.6.3 — Run the regression checklist on dev
 - [ ] TASK-42.6.4 — Build from master with the release content, deploy to a near-production environment
 - [ ] TASK-42.6.5 — Verify each of the 6 release items on the master build
 - [ ] TASK-42.6.6 — Run the regression checklist on the master build
@@ -81,17 +81,17 @@ Run this list at each stage (dev, master, draft, production quick recheck at red
 
 ## Bugs found
 
-Not tested yet.
+None found on dev merge stage.
 
 ## Test notes
 
-- **Tested on**: not tested yet
+- **Tested on**: Dev merge — pass. Master build, draft release, production not tested yet.
 - **Environment**: dev → master build → draft release → production (all 4 stages)
-- **Passed**: pending
+- **Passed**: 2 / 7 AC (dev merge stage); remaining stages pending
 
 ## Retest
 
-N/A — not tested yet.
+N/A — no bugs found on dev merge. Remaining stages still to be done.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
+++ b/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
@@ -1,6 +1,6 @@
 ---
 id: US-42.7
-title: "QC — Add recommend validator for native and subnet staking on Extension (#5024)"
+title: "QC — Add recommend validator for native and subnet staking (#5024)"
 epic: EPIC-42
 status: in-progress
 priority: P2
@@ -11,34 +11,40 @@ prd_ref: []
 assignee: 
 commit:
 created: 2026-07-21
-updated: 2026-07-21
+updated: 2026-07-22
 ---
 
 ## Goal
 
-Verify the "Recommend validator" feature for native staking and subnet staking on the **Extension**. Ensure the recommended validators are populated correctly and the selection works seamlessly in both fresh install and upgrade scenarios.
+Verify the "Recommend validator" feature for native staking and subnet staking on the PR build, across all 3 platforms (Extension, Web App, Mobile). Ensure the recommended validators are populated correctly and the selection works seamlessly in both fresh install and upgrade scenarios.
 
 ## Background
 
 This QC story covers the implementation of [issue #5024](https://github.com/Koniverse/SubWallet-Extension/issues/5024): Add recommend validator for native and subnet staking.
-This story covers the **Extension only**. Web App and Mobile ship on their own release schedules, so a separate story will be created for them when that testing starts — keeping platforms in one story would tie their release gates together when they shouldn't be.
+This is a PR-level check, not a release — all 3 platforms are tested together here. Each platform still ships and gets release-gated on its own schedule separately (e.g. [US-42.6](US-42.6-qc-release-extension-v1-3-84.md) for Extension, [US-42.9](US-42.9-qc-release-webapp-v1-3-56-0.md) for Web App).
 
 ## Acceptance criteria
 
-- [x] **AC-1**: When user initiates native staking, the system provides a "Recommended" validator option or automatically selects the best validators.
-- [x] **AC-2**: When user initiates subnet staking, the system correctly suggests recommended subnet validators.
-- [x] **AC-3**: The recommended validators meet expected criteria (e.g., active status, identity, reasonable commission).
-- [x] **AC-4**: The user can choose to override the recommended validators and select their own manually.
+- [x] **AC-1**: When user initiates native staking, the system provides a "Recommended" validator option or automatically selects the best validators. _(verified on Extension + Web App)_
+- [x] **AC-2**: When user initiates subnet staking, the system correctly suggests recommended subnet validators. _(verified on Extension + Web App)_
+- [x] **AC-3**: The recommended validators meet expected criteria (e.g., active status, identity, reasonable commission). _(verified on Extension + Web App)_
+- [x] **AC-4**: The user can choose to override the recommended validators and select their own manually. _(verified on Extension + Web App)_
 - [x] **AC-5**: AC-1 to AC-4 work smoothly on the Extension without UI glitches or crashes.
-- [x] **AC-6**: The feature behaves correctly on a fresh install of the Extension.
-- [x] **AC-7**: The feature behaves correctly on a version upgrade of the Extension (existing accounts and data are preserved).
+- [x] **AC-6**: AC-1 to AC-4 work smoothly on the Web App without UI glitches or crashes.
+- [ ] **AC-7**: AC-1 to AC-4 work smoothly on the Mobile App without UI glitches or crashes. — **not tested yet**
+- [ ] **AC-8**: The feature behaves correctly on a fresh install across all platforms. — Extension + Web App pass; Mobile pending
+- [ ] **AC-9**: The feature behaves correctly on a version upgrade across all platforms (existing accounts and data are preserved). — Extension + Web App pass; Mobile pending
 
 ## Tasks
 
-- [x] TASK-42.7.1 — Test Native & Subnet staking recommended flow on a fresh install.
-- [x] TASK-42.7.2 — Test Native & Subnet staking recommended flow on an upgraded version.
-- [x] TASK-42.7.3 — Verify user can unselect recommended validators and manually pick others.
-- [x] TASK-42.7.4 — Log any bugs found.
+- [x] TASK-42.7.1 — Extension: Test Native & Subnet staking recommended flow on a fresh install.
+- [x] TASK-42.7.2 — Extension: Test Native & Subnet staking recommended flow on an upgraded version.
+- [x] TASK-42.7.3 — Web App: Test Native & Subnet staking recommended flow on a fresh install.
+- [x] TASK-42.7.4 — Web App: Test Native & Subnet staking recommended flow on an upgraded version.
+- [ ] TASK-42.7.5 — Mobile: Test Native & Subnet staking recommended flow on a fresh install. — **not started**
+- [ ] TASK-42.7.6 — Mobile: Test Native & Subnet staking recommended flow on an upgraded version. — **not started**
+- [x] TASK-42.7.7 — Verify user can unselect recommended validators and manually pick others on all platforms. _(Extension + Web App done; Mobile pending)_
+- [x] TASK-42.7.8 — Log any bugs found.
 
 ## Bugs found
 
@@ -46,19 +52,21 @@ This story covers the **Extension only**. Web App and Mobile ship on their own r
 |---|---|---|---|
 | — | — | — | — |
 
-None found.
+None found on Extension or Web App.
 
 ## Test notes
 
-- **Tested on**: Extension (Chrome) — pass.
+- **Tested on**: Extension (Chrome), Web App — both pass. Mobile (iOS/Android) not tested yet.
 - **Environment**: PR build / Staging
-- **AC passed**: 7 / 7
+- **AC passed**: 6 / 9 (AC-7, AC-8, AC-9 pending Mobile)
 
 ## Retest
 
-N/A — no bugs found.
+N/A — no bugs found on Extension/Web App. Mobile testing still to be done.
 
 ## Cross-references
 
 - [Issue #5024](https://github.com/Koniverse/SubWallet-Extension/issues/5024)
+- [US-42.6](US-42.6-qc-release-extension-v1-3-84.md) — Extension release gate that includes this feature
+- [US-42.9](US-42.9-qc-release-webapp-v1-3-56-0.md) — Web App release gate that includes this feature
 - Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
+++ b/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit:
+commit: 94d67ea852, 1a782ee974, 46f7d93b8b
 created: 2026-07-21
 updated: 2026-07-22
 ---


### PR DESCRIPTION
## Summary
- Mark US-42.6 dev merge stage (AC-1, AC-2, TASK-42.6.1–3) as passed.
- Merge Extension/Web App/Mobile back into a single US-42.7 (PR-level test, not a per-platform release), mark Web App as passed.
- Fill in the `commit:` frontmatter field for US-42.6 and US-42.7 with their own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected