### PR TITLE
docs: mark US-42.9 dev and US-42.6 master build stages as passed

### DIFF
--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: MaiThuongNinni
-commit: a11851b32b, 1a782ee974, 962cc44f39
+commit: a11851b32b, 1a782ee974, 962cc44f39, 96520205db
 created: 2026-07-21
 updated: 2026-07-21
 ---

--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -43,8 +43,8 @@ Each of these items already has its own QC story (US-42.1 to US-42.5, US-42.7) c
 
 - [x] AC-1: All 6 release items (US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM, recommend validator #5024) work correctly after merge into the dev environment
 - [x] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
-- [ ] AC-3: All 6 release items work correctly on the master build
-- [ ] AC-4: Regression pass on the master build finds no new issues in the app's main functions
+- [x] AC-3: All 6 release items work correctly on the master build
+- [x] AC-4: Regression pass on the master build finds no new issues in the app's main functions
 - [ ] AC-5: All 6 release items work correctly on the draft release build
 - [ ] AC-6: Regression pass on the draft release build finds no new issues in the app's main functions
 - [ ] AC-7: Quick recheck on production confirms the release content is live and working, no critical issues
@@ -70,9 +70,9 @@ Run this list at each stage (dev, master, draft, production quick recheck at red
 - [x] TASK-42.6.1 — Merge US-5013, MYTH XCM, TUSDT, Cypress, Polkadot Hub EVM, and recommend validator (#5024) into the extension on dev
 - [x] TASK-42.6.2 — Verify each of the 6 release items on dev (link to US-42.1 to US-42.5, US-42.7 for detailed steps)
 - [x] TASK-42.6.3 — Run the regression checklist on dev
-- [ ] TASK-42.6.4 — Build from master with the release content, deploy to a near-production environment
-- [ ] TASK-42.6.5 — Verify each of the 6 release items on the master build
-- [ ] TASK-42.6.6 — Run the regression checklist on the master build
+- [x] TASK-42.6.4 — Build from master with the release content, deploy to a near-production environment
+- [x] TASK-42.6.5 — Verify each of the 6 release items on the master build
+- [x] TASK-42.6.6 — Run the regression checklist on the master build
 - [ ] TASK-42.6.7 — Test the draft release build (production-like, draft form)
 - [ ] TASK-42.6.8 — Verify each of the 6 release items on the draft build
 - [ ] TASK-42.6.9 — Run the regression checklist on the draft build
@@ -81,17 +81,17 @@ Run this list at each stage (dev, master, draft, production quick recheck at red
 
 ## Bugs found
 
-None found on dev merge stage.
+None found on dev merge or master build stages.
 
 ## Test notes
 
-- **Tested on**: Dev merge — pass. Master build, draft release, production not tested yet.
+- **Tested on**: Dev merge, master build — both pass. Draft release, production not tested yet.
 - **Environment**: dev → master build → draft release → production (all 4 stages)
-- **Passed**: 2 / 7 AC (dev merge stage); remaining stages pending
+- **Passed**: 4 / 7 AC (dev merge + master build stages); remaining stages pending
 
 ## Retest
 
-N/A — no bugs found on dev merge. Remaining stages still to be done.
+N/A — no bugs found on dev merge or master build. Remaining stages still to be done.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
+++ b/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
@@ -33,8 +33,8 @@ This is the Web App counterpart to the Extension release of the same feature ([U
 
 ## Things to check
 
-- [ ] AC-1: Recommend validator (#5024) merged into web app dev and works correctly (native + subnet staking)
-- [ ] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
+- [x] AC-1: Recommend validator (#5024) merged into web app dev and works correctly (native + subnet staking)
+- [x] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
 - [ ] AC-3: Recommend validator (#5024) works correctly on production
 - [ ] AC-4: Regression pass on production finds no new issues in the app's main functions
 
@@ -54,26 +54,26 @@ Run this list at each stage (dev, production):
 
 ## Steps
 
-- [ ] TASK-42.9.1 — Merge PR for recommend validator (#5024) into web app dev
-- [ ] TASK-42.9.2 — Verify recommend validator feature works on dev (native + subnet staking, override works) — link to US-42.7 for detailed steps
-- [ ] TASK-42.9.3 — Run the regression checklist on dev
+- [x] TASK-42.9.1 — Merge PR for recommend validator (#5024) into web app dev
+- [x] TASK-42.9.2 — Verify recommend validator feature works on dev (native + subnet staking, override works) — link to US-42.7 for detailed steps
+- [x] TASK-42.9.3 — Run the regression checklist on dev
 - [ ] TASK-42.9.4 — After release ships to production, verify recommend validator feature works on production
 - [ ] TASK-42.9.5 — Run the regression checklist on production
 - [ ] TASK-42.9.6 — Log any bugs found, tag with the stage they were found on (dev / production)
 
 ## Bugs found
 
-Not tested yet.
+None found on dev stage.
 
 ## Test notes
 
-- **Tested on**: not tested yet
+- **Tested on**: Dev — pass. Production not tested yet.
 - **Environment**: dev → production
-- **Passed**: pending
+- **Passed**: 2 / 4 AC (dev stage); production pending
 
 ## Retest
 
-N/A — not tested yet.
+N/A — no bugs found on dev. Production stage still to be done.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
+++ b/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit:
+commit: 8396353470
 created: 2026-07-22
 updated: 2026-07-22
 ---


### PR DESCRIPTION
## Summary
- US-42.9 (Web App release v1.3.56-0): mark the Dev stage (AC-1, AC-2, TASK-42.9.1–3) as passed.
- US-42.6 (Extension release v1.3.84): mark the Master build stage (AC-3, AC-4, TASK-42.6.4–6) as passed.
- Fill in the `commit:` frontmatter field for both stories with their own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected