### PR TITLE
docs: close US-42.7, all AC pass on Extension/Web App/Mobile

### DIFF
--- a/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
+++ b/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
@@ -2,7 +2,7 @@
 id: US-42.7
 title: "QC — Add recommend validator for native and subnet staking (#5024)"
 epic: EPIC-42
-status: in-progress
+status: done
 priority: P2
 points: 5
 sprint: sprint-2026-W30
@@ -25,15 +25,15 @@ This is a PR-level check, not a release — all 3 platforms are tested together 
 
 ## Acceptance criteria
 
-- [x] **AC-1**: When user initiates native staking, the system provides a "Recommended" validator option or automatically selects the best validators. _(verified on Extension + Web App)_
-- [x] **AC-2**: When user initiates subnet staking, the system correctly suggests recommended subnet validators. _(verified on Extension + Web App)_
-- [x] **AC-3**: The recommended validators meet expected criteria (e.g., active status, identity, reasonable commission). _(verified on Extension + Web App)_
-- [x] **AC-4**: The user can choose to override the recommended validators and select their own manually. _(verified on Extension + Web App)_
+- [x] **AC-1**: When user initiates native staking, the system provides a "Recommended" validator option or automatically selects the best validators. _(verified on Extension + Web App + Mobile)_
+- [x] **AC-2**: When user initiates subnet staking, the system correctly suggests recommended subnet validators. _(verified on Extension + Web App + Mobile)_
+- [x] **AC-3**: The recommended validators meet expected criteria (e.g., active status, identity, reasonable commission). _(verified on Extension + Web App + Mobile)_
+- [x] **AC-4**: The user can choose to override the recommended validators and select their own manually. _(verified on Extension + Web App + Mobile)_
 - [x] **AC-5**: AC-1 to AC-4 work smoothly on the Extension without UI glitches or crashes.
 - [x] **AC-6**: AC-1 to AC-4 work smoothly on the Web App without UI glitches or crashes.
-- [ ] **AC-7**: AC-1 to AC-4 work smoothly on the Mobile App without UI glitches or crashes. — **not tested yet**
-- [ ] **AC-8**: The feature behaves correctly on a fresh install across all platforms. — Extension + Web App pass; Mobile pending
-- [ ] **AC-9**: The feature behaves correctly on a version upgrade across all platforms (existing accounts and data are preserved). — Extension + Web App pass; Mobile pending
+- [x] **AC-7**: AC-1 to AC-4 work smoothly on the Mobile App without UI glitches or crashes. _(iOS + Android)_
+- [x] **AC-8**: The feature behaves correctly on a fresh install across all platforms.
+- [x] **AC-9**: The feature behaves correctly on a version upgrade across all platforms (existing accounts and data are preserved).
 
 ## Tasks
 
@@ -41,9 +41,9 @@ This is a PR-level check, not a release — all 3 platforms are tested together 
 - [x] TASK-42.7.2 — Extension: Test Native & Subnet staking recommended flow on an upgraded version.
 - [x] TASK-42.7.3 — Web App: Test Native & Subnet staking recommended flow on a fresh install.
 - [x] TASK-42.7.4 — Web App: Test Native & Subnet staking recommended flow on an upgraded version.
-- [ ] TASK-42.7.5 — Mobile: Test Native & Subnet staking recommended flow on a fresh install. — **not started**
-- [ ] TASK-42.7.6 — Mobile: Test Native & Subnet staking recommended flow on an upgraded version. — **not started**
-- [x] TASK-42.7.7 — Verify user can unselect recommended validators and manually pick others on all platforms. _(Extension + Web App done; Mobile pending)_
+- [x] TASK-42.7.5 — Mobile: Test Native & Subnet staking recommended flow on a fresh install. _(iOS + Android)_
+- [x] TASK-42.7.6 — Mobile: Test Native & Subnet staking recommended flow on an upgraded version. _(iOS + Android)_
+- [x] TASK-42.7.7 — Verify user can unselect recommended validators and manually pick others on all platforms.
 - [x] TASK-42.7.8 — Log any bugs found.
 
 ## Bugs found
@@ -52,17 +52,17 @@ This is a PR-level check, not a release — all 3 platforms are tested together 
 |---|---|---|---|
 | — | — | — | — |
 
-None found on Extension or Web App.
+None found on Extension, Web App, or Mobile.
 
 ## Test notes
 
-- **Tested on**: Extension (Chrome), Web App — both pass. Mobile (iOS/Android) not tested yet.
+- **Tested on**: Extension (Chrome), Web App, Mobile (iOS + Android) — all pass.
 - **Environment**: PR build / Staging
-- **AC passed**: 6 / 9 (AC-7, AC-8, AC-9 pending Mobile)
+- **AC passed**: 9 / 9
 
 ## Retest
 
-N/A — no bugs found on Extension/Web App. Mobile testing still to be done.
+N/A — no bugs found on any platform.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
+++ b/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit: 94d67ea852, 1a782ee974, 46f7d93b8b, 2c74d533ff
+commit: 94d67ea852, 1a782ee974, 46f7d93b8b, 2c74d533ff, cf7c319b8f
 created: 2026-07-21
 updated: 2026-07-22
 ---

--- a/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
+++ b/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
@@ -48,10 +48,6 @@ This is a PR-level check, not a release — all 3 platforms are tested together 
 
 ## Bugs found
 
-| ID | Title | Severity | Status |
-|---|---|---|---|
-| — | — | — | — |
-
 None found on Extension, Web App, or Mobile.
 
 ## Test notes

--- a/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
+++ b/docs/sprints/stories/US-42.7-qc-recommend-validator-native-subnet-staking.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit: 94d67ea852, 1a782ee974, 46f7d93b8b
+commit: 94d67ea852, 1a782ee974, 46f7d93b8b, 2c74d533ff
 created: 2026-07-21
 updated: 2026-07-22
 ---


### PR DESCRIPTION
## Summary
- Close US-42.7 — recommend validator (#5024) all 9 AC pass across Extension, Web App, and Mobile (iOS + Android), no bugs found.
- Clean up the empty "Bugs found" table, keep only the plain no-bugs note per convention.
- Fill in the `commit:` frontmatter field with the story's own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected