### PR TITLE
docs: fix status field for US-42.6/US-42.9 to in-progress

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -39,9 +39,9 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.3](../stories/US-42.3-qc-polkadot-hub-evm-chain.md) | Polkadot Hub EVM chain works correctly (#701) | done |
 | [US-42.4](../stories/US-42.4-qc-tusdt-on-bittensor.md) | TUSDT token on Bittensor shows correctly (#699) | done |
 | [US-42.5](../stories/US-42.5-qc-myth-xcm-pah-hydration.md) | MYTH XCM between PAH and Hydration retest (#301) | done |
-| [US-42.6](../stories/US-42.6-qc-release-extension-v1-3-84.md) | Release extension v1.3.84 — dev, master, draft, production gate | ready |
-| [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — PR test, all 3 platforms (#5024) | in-progress |
-| [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | ready |
+| [US-42.6](../stories/US-42.6-qc-release-extension-v1-3-84.md) | Release extension v1.3.84 — dev, master, draft, production gate | in-progress |
+| [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — PR test, all 3 platforms (#5024) | done |
+| [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | in-progress |
 | [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-xx.md) | Release Mobile v1.2.xx(xxx)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | ready |
 
 More rows get added here as testing starts.

--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -2,7 +2,7 @@
 id: US-42.6
 title: "QC — Release SubWallet Extension v1.3.84"
 epic: EPIC-42
-status: ready
+status: in-progress
 priority: P2
 points: 8
 sprint: sprint-2026-W30

--- a/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
+++ b/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
@@ -2,7 +2,7 @@
 id: US-42.9
 title: "QC — Release SubWallet Web App v1.3.56-0 (build 1356-0014)"
 epic: EPIC-42
-status: ready
+status: in-progress
 priority: P2
 points: 5
 sprint: sprint-2026-W30


### PR DESCRIPTION
## Summary
- Fix `status:` frontmatter on US-42.6 and US-42.9 from `ready` to `in-progress` — both stories already have test progress recorded (US-42.6 dev merge + master build passed, US-42.9 dev stage passed), so `ready` was stale.
- Sync EPIC-42 QA tracking table status column to match.

## Test plan
- [ ] Docs-only change, no code affected