### PR TITLE
docs: close US-42.9, Web App release v1.3.56-0 all AC pass

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -41,7 +41,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.5](../stories/US-42.5-qc-myth-xcm-pah-hydration.md) | MYTH XCM between PAH and Hydration retest (#301) | done |
 | [US-42.6](../stories/US-42.6-qc-release-extension-v1-3-84.md) | Release extension v1.3.84 — dev, master, draft, production gate | in-progress |
 | [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — PR test, all 3 platforms (#5024) | done |
-| [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | in-progress |
+| [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | done |
 | [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-xx.md) | Release Mobile v1.2.xx(xxx)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | ready |
 
 More rows get added here as testing starts.

--- a/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
+++ b/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
@@ -2,7 +2,7 @@
 id: US-42.9
 title: "QC — Release SubWallet Web App v1.3.56-0 (build 1356-0014)"
 epic: EPIC-42
-status: in-progress
+status: done
 priority: P2
 points: 5
 sprint: sprint-2026-W30
@@ -35,8 +35,8 @@ This is the Web App counterpart to the Extension release of the same feature ([U
 
 - [x] AC-1: Recommend validator (#5024) merged into web app dev and works correctly (native + subnet staking)
 - [x] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
-- [ ] AC-3: Recommend validator (#5024) works correctly on production
-- [ ] AC-4: Regression pass on production finds no new issues in the app's main functions
+- [x] AC-3: Recommend validator (#5024) works correctly on production
+- [x] AC-4: Regression pass on production finds no new issues in the app's main functions
 
 ## Regression checklist (main functions)
 
@@ -57,23 +57,23 @@ Run this list at each stage (dev, production):
 - [x] TASK-42.9.1 — Merge PR for recommend validator (#5024) into web app dev
 - [x] TASK-42.9.2 — Verify recommend validator feature works on dev (native + subnet staking, override works) — link to US-42.7 for detailed steps
 - [x] TASK-42.9.3 — Run the regression checklist on dev
-- [ ] TASK-42.9.4 — After release ships to production, verify recommend validator feature works on production
-- [ ] TASK-42.9.5 — Run the regression checklist on production
-- [ ] TASK-42.9.6 — Log any bugs found, tag with the stage they were found on (dev / production)
+- [x] TASK-42.9.4 — After release ships to production, verify recommend validator feature works on production
+- [x] TASK-42.9.5 — Run the regression checklist on production
+- [x] TASK-42.9.6 — Log any bugs found, tag with the stage they were found on (dev / production)
 
 ## Bugs found
 
-None found on dev stage.
+None found on dev or production.
 
 ## Test notes
 
-- **Tested on**: Dev — pass. Production not tested yet.
+- **Tested on**: Dev, production — both pass.
 - **Environment**: dev → production
-- **Passed**: 2 / 4 AC (dev stage); production pending
+- **Passed**: 4 / 4 AC
 
 ## Retest
 
-N/A — no bugs found on dev. Production stage still to be done.
+N/A — no bugs found on any stage.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
+++ b/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit: 8396353470
+commit: 8396353470, f212321da3
 created: 2026-07-22
 updated: 2026-07-22
 ---


### PR DESCRIPTION
## Summary
- Close US-42.9 — recommend validator (#5024) release for Web App v1.3.56-0, both Dev and Production stages pass, 4/4 AC done, no bugs found.
- Fill in the `commit:` frontmatter field with the story's own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected