### PR TITLE
docs: mark US-42.6 draft release and US-42.9 regression checklist as passed

### DIFF
--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: MaiThuongNinni
-commit: a11851b32b, 1a782ee974, 962cc44f39, 96520205db
+commit: a11851b32b, 1a782ee974, 962cc44f39, 96520205db, 660f106839
 created: 2026-07-21
 updated: 2026-07-21
 ---

--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -45,25 +45,25 @@ Each of these items already has its own QC story (US-42.1 to US-42.5, US-42.7) c
 - [x] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
 - [x] AC-3: All 6 release items work correctly on the master build
 - [x] AC-4: Regression pass on the master build finds no new issues in the app's main functions
-- [ ] AC-5: All 6 release items work correctly on the draft release build
-- [ ] AC-6: Regression pass on the draft release build finds no new issues in the app's main functions
+- [x] AC-5: All 6 release items work correctly on the draft release build
+- [x] AC-6: Regression pass on the draft release build finds no new issues in the app's main functions
 - [ ] AC-7: Quick recheck on production confirms the release content is live and working, no critical issues
 
 ## Regression checklist (main functions)
 
 Run this list at each stage (dev, master, draft, production quick recheck at reduced depth):
 
-- [ ] Create a new account / import an existing account (mnemonic, private key)
-- [ ] Switch between accounts, view balances across chains
-- [ ] Send a native token, confirm it goes through with correct fee display
-- [ ] Receive a token (show/copy address, QR)
-- [ ] Swap tokens (at least one route)
-- [ ] Stake/unstake on at least one network (covers the US-5013 regression area)
-- [ ] Start a native/subnet staking flow and confirm the recommended validator suggestion appears and can be overridden (covers the #5024 regression area)
-- [ ] XCM transfer between two chains
-- [ ] Connect to a dApp (WalletConnect or injected), sign a message/transaction
-- [ ] Export account (JSON / seed phrase) and remove account
-- [ ] App upgrade path: install previous version, add data, upgrade, confirm data and settings are preserved
+- [x] Create a new account / import an existing account (mnemonic, private key)
+- [x] Switch between accounts, view balances across chains
+- [x] Send a native token, confirm it goes through with correct fee display
+- [x] Receive a token (show/copy address, QR)
+- [x] Swap tokens (at least one route)
+- [x] Stake/unstake on at least one network (covers the US-5013 regression area)
+- [x] Start a native/subnet staking flow and confirm the recommended validator suggestion appears and can be overridden (covers the #5024 regression area)
+- [x] XCM transfer between two chains
+- [x] Connect to a dApp (WalletConnect or injected), sign a message/transaction
+- [x] Export account (JSON / seed phrase) and remove account
+- [x] App upgrade path: install previous version, add data, upgrade, confirm data and settings are preserved
 
 ## Steps
 
@@ -73,25 +73,25 @@ Run this list at each stage (dev, master, draft, production quick recheck at red
 - [x] TASK-42.6.4 — Build from master with the release content, deploy to a near-production environment
 - [x] TASK-42.6.5 — Verify each of the 6 release items on the master build
 - [x] TASK-42.6.6 — Run the regression checklist on the master build
-- [ ] TASK-42.6.7 — Test the draft release build (production-like, draft form)
-- [ ] TASK-42.6.8 — Verify each of the 6 release items on the draft build
-- [ ] TASK-42.6.9 — Run the regression checklist on the draft build
+- [x] TASK-42.6.7 — Test the draft release build (production-like, draft form)
+- [x] TASK-42.6.8 — Verify each of the 6 release items on the draft build
+- [x] TASK-42.6.9 — Run the regression checklist on the draft build
 - [ ] TASK-42.6.10 — After publish, do a quick recheck of the release content and core functions on production
 - [ ] TASK-42.6.11 — Log any bugs found, tag with the stage they were found on (dev / master / draft / production)
 
 ## Bugs found
 
-None found on dev merge or master build stages.
+None found on dev merge, master build, or draft release stages.
 
 ## Test notes
 
-- **Tested on**: Dev merge, master build — both pass. Draft release, production not tested yet.
+- **Tested on**: Dev merge, master build, draft release — all pass. Production not tested yet.
 - **Environment**: dev → master build → draft release → production (all 4 stages)
-- **Passed**: 4 / 7 AC (dev merge + master build stages); remaining stages pending
+- **Passed**: 6 / 7 AC (dev merge + master build + draft release stages); production pending
 
 ## Retest
 
-N/A — no bugs found on dev merge or master build. Remaining stages still to be done.
+N/A — no bugs found on dev merge, master build, or draft release. Production stage still to be done.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
+++ b/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit: 8396353470, f212321da3
+commit: 8396353470, f212321da3, bebbcab4b1
 created: 2026-07-22
 updated: 2026-07-22
 ---

--- a/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
+++ b/docs/sprints/stories/US-42.9-qc-release-webapp-v1-3-56-0.md
@@ -42,15 +42,15 @@ This is the Web App counterpart to the Extension release of the same feature ([U
 
 Run this list at each stage (dev, production):
 
-- [ ] Create a new account / import an existing account (mnemonic, private key)
-- [ ] Switch between accounts, view balances across chains
-- [ ] Send a native token, confirm it goes through with correct fee display
-- [ ] Receive a token (show/copy address, QR)
-- [ ] Swap tokens (at least one route)
-- [ ] Stake/unstake on at least one network
-- [ ] XCM transfer between two chains
-- [ ] Connect to a dApp (WalletConnect or injected), sign a message/transaction
-- [ ] Export account (JSON / seed phrase) and remove account
+- [x] Create a new account / import an existing account (mnemonic, private key)
+- [x] Switch between accounts, view balances across chains
+- [x] Send a native token, confirm it goes through with correct fee display
+- [x] Receive a token (show/copy address, QR)
+- [x] Swap tokens (at least one route)
+- [x] Stake/unstake on at least one network
+- [x] XCM transfer between two chains
+- [x] Connect to a dApp (WalletConnect or injected), sign a message/transaction
+- [x] Export account (JSON / seed phrase) and remove account
 
 ## Steps
 


### PR DESCRIPTION
## Summary
- US-42.6 (Extension release v1.3.84): mark the Draft release stage (AC-5, AC-6, TASK-42.6.7–9) as passed, all 10 regression-checklist items passed across dev/master/draft stages.
- US-42.9 (Web App release v1.3.56-0): mark all 9 regression-checklist items as passed.
- Fill in the `commit:` frontmatter field for both stories with their own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected