### PR TITLE
docs: close US-42.6, Extension release v1.3.84 all AC pass

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -39,7 +39,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.3](../stories/US-42.3-qc-polkadot-hub-evm-chain.md) | Polkadot Hub EVM chain works correctly (#701) | done |
 | [US-42.4](../stories/US-42.4-qc-tusdt-on-bittensor.md) | TUSDT token on Bittensor shows correctly (#699) | done |
 | [US-42.5](../stories/US-42.5-qc-myth-xcm-pah-hydration.md) | MYTH XCM between PAH and Hydration retest (#301) | done |
-| [US-42.6](../stories/US-42.6-qc-release-extension-v1-3-84.md) | Release extension v1.3.84 — dev, master, draft, production gate | in-progress |
+| [US-42.6](../stories/US-42.6-qc-release-extension-v1-3-84.md) | Release extension v1.3.84 — dev, master, draft, production gate | done |
 | [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — PR test, all 3 platforms (#5024) | done |
 | [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | done |
 | [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-xx.md) | Release Mobile v1.2.xx(xxx)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | ready |

--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -2,7 +2,7 @@
 id: US-42.6
 title: "QC — Release SubWallet Extension v1.3.84"
 epic: EPIC-42
-status: in-progress
+status: done
 priority: P2
 points: 8
 sprint: sprint-2026-W30
@@ -47,7 +47,7 @@ Each of these items already has its own QC story (US-42.1 to US-42.5, US-42.7) c
 - [x] AC-4: Regression pass on the master build finds no new issues in the app's main functions
 - [x] AC-5: All 6 release items work correctly on the draft release build
 - [x] AC-6: Regression pass on the draft release build finds no new issues in the app's main functions
-- [ ] AC-7: Quick recheck on production confirms the release content is live and working, no critical issues
+- [x] AC-7: Quick recheck on production confirms the release content is live and working, no critical issues
 
 ## Regression checklist (main functions)
 
@@ -76,22 +76,22 @@ Run this list at each stage (dev, master, draft, production quick recheck at red
 - [x] TASK-42.6.7 — Test the draft release build (production-like, draft form)
 - [x] TASK-42.6.8 — Verify each of the 6 release items on the draft build
 - [x] TASK-42.6.9 — Run the regression checklist on the draft build
-- [ ] TASK-42.6.10 — After publish, do a quick recheck of the release content and core functions on production
-- [ ] TASK-42.6.11 — Log any bugs found, tag with the stage they were found on (dev / master / draft / production)
+- [x] TASK-42.6.10 — After publish, do a quick recheck of the release content and core functions on production
+- [x] TASK-42.6.11 — Log any bugs found, tag with the stage they were found on (dev / master / draft / production)
 
 ## Bugs found
 
-None found on dev merge, master build, or draft release stages.
+None found on any stage (dev merge, master build, draft release, production).
 
 ## Test notes
 
-- **Tested on**: Dev merge, master build, draft release — all pass. Production not tested yet.
+- **Tested on**: Dev merge, master build, draft release, production — all pass.
 - **Environment**: dev → master build → draft release → production (all 4 stages)
-- **Passed**: 6 / 7 AC (dev merge + master build + draft release stages); production pending
+- **Passed**: 7 / 7 AC
 
 ## Retest
 
-N/A — no bugs found on dev merge, master build, or draft release. Production stage still to be done.
+N/A — no bugs found on any stage.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
+++ b/docs/sprints/stories/US-42.6-qc-release-extension-v1-3-84.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: MaiThuongNinni
-commit: a11851b32b, 1a782ee974, 962cc44f39, 96520205db, 660f106839
+commit: a11851b32b, 1a782ee974, 962cc44f39, 96520205db, 660f106839, fd320c03a9
 created: 2026-07-21
 updated: 2026-07-21
 ---


### PR DESCRIPTION
## Summary
- Close US-42.6 — Extension release v1.3.84 release gate complete, all 7 AC pass across all 4 stages (dev merge, master build, draft release, production), no bugs found.
- Sync EPIC-42 QA tracking table status column.
- Fill in the `commit:` frontmatter field with the story's own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected