### PR TITLE
docs: mark US-42.10 iOS+Android beta stages as passed

### DIFF
--- a/docs/sprints/stories/US-42.10-qc-release-mobile-v1-2-xx.md
+++ b/docs/sprints/stories/US-42.10-qc-release-mobile-v1-2-xx.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit: 9173b80b9f, febe0327f6
+commit: 9173b80b9f, febe0327f6, 379358fd12
 created: 2026-07-22
 updated: 2026-07-22
 ---

--- a/docs/sprints/stories/US-42.10-qc-release-mobile-v1-2-xx.md
+++ b/docs/sprints/stories/US-42.10-qc-release-mobile-v1-2-xx.md
@@ -2,14 +2,14 @@
 id: US-42.10
 title: "QC — Release SubWallet Mobile v1.2.xx(xxx)b-v16"
 epic: EPIC-42
-status: ready
+status: in-progress
 priority: P2
 points: 8
 sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit: 9173b80b9f
+commit: 9173b80b9f, febe0327f6
 created: 2026-07-22
 updated: 2026-07-22
 ---
@@ -37,10 +37,10 @@ This is the Mobile counterpart to the same feature already QC'd on Extension ([U
 
 ## Things to check
 
-- [ ] AC-1: Recommend validator (#5024) works correctly on the iOS TestFlight build
-- [ ] AC-2: Regression pass on iOS TestFlight finds no new issues, on both fresh install and upgrade (see Regression checklist)
-- [ ] AC-3: Recommend validator (#5024) works correctly on the Android Google Play beta build
-- [ ] AC-4: Regression pass on Android Google Play beta finds no new issues, on both fresh install and upgrade (see Regression checklist)
+- [x] AC-1: Recommend validator (#5024) works correctly on the iOS TestFlight build
+- [x] AC-2: Regression pass on iOS TestFlight finds no new issues, on both fresh install and upgrade (see Regression checklist)
+- [x] AC-3: Recommend validator (#5024) works correctly on the Android Google Play beta build
+- [x] AC-4: Regression pass on Android Google Play beta finds no new issues, on both fresh install and upgrade (see Regression checklist)
 - [ ] AC-5: Quick recheck on iOS App Store production confirms the release content is live and working, no critical issues
 - [ ] AC-6: Quick recheck on Android Google Play production confirms the release content is live and working, no critical issues
 
@@ -48,44 +48,44 @@ This is the Mobile counterpart to the same feature already QC'd on Extension ([U
 
 Run this list on each beta stage (iOS TestFlight, Android Google Play beta), on both a fresh install and a version upgrade; run a reduced-depth version for the production quick checks:
 
-- [ ] Create a new account / import an existing account (mnemonic, private key)
-- [ ] Switch between accounts, view balances across chains
-- [ ] Send a native token, confirm it goes through with correct fee display
-- [ ] Receive a token (show/copy address, QR)
-- [ ] Swap tokens (at least one route)
-- [ ] Start a native/subnet staking flow and confirm the recommended validator suggestion appears and can be overridden (covers the #5024 regression area)
-- [ ] Stake/unstake on at least one network
-- [ ] Connect to a dApp (WalletConnect), sign a message/transaction
-- [ ] Export account (JSON / seed phrase) and remove account
-- [ ] App upgrade path: install previous version, add data, upgrade, confirm data and settings are preserved
+- [x] Create a new account / import an existing account (mnemonic, private key)
+- [x] Switch between accounts, view balances across chains
+- [x] Send a native token, confirm it goes through with correct fee display
+- [x] Receive a token (show/copy address, QR)
+- [x] Swap tokens (at least one route)
+- [x] Start a native/subnet staking flow and confirm the recommended validator suggestion appears and can be overridden (covers the #5024 regression area)
+- [x] Stake/unstake on at least one network
+- [x] Connect to a dApp (WalletConnect), sign a message/transaction
+- [x] Export account (JSON / seed phrase) and remove account
+- [x] App upgrade path: install previous version, add data, upgrade, confirm data and settings are preserved
 
 ## Steps
 
-- [ ] TASK-42.10.1 — iOS: Push build to TestFlight
-- [ ] TASK-42.10.2 — iOS: Verify recommend validator feature on TestFlight (link to US-42.7 for detailed steps)
-- [ ] TASK-42.10.3 — iOS: Run the regression checklist on a fresh install
-- [ ] TASK-42.10.4 — iOS: Run the regression checklist on a version upgrade
-- [ ] TASK-42.10.5 — Android: Push build to Google Play beta track
-- [ ] TASK-42.10.6 — Android: Verify recommend validator feature on Google Play beta (link to US-42.7 for detailed steps)
-- [ ] TASK-42.10.7 — Android: Run the regression checklist on a fresh install
-- [ ] TASK-42.10.8 — Android: Run the regression checklist on a version upgrade
+- [x] TASK-42.10.1 — iOS: Push build to TestFlight
+- [x] TASK-42.10.2 — iOS: Verify recommend validator feature on TestFlight (link to US-42.7 for detailed steps)
+- [x] TASK-42.10.3 — iOS: Run the regression checklist on a fresh install
+- [x] TASK-42.10.4 — iOS: Run the regression checklist on a version upgrade
+- [x] TASK-42.10.5 — Android: Push build to Google Play beta track
+- [x] TASK-42.10.6 — Android: Verify recommend validator feature on Google Play beta (link to US-42.7 for detailed steps)
+- [x] TASK-42.10.7 — Android: Run the regression checklist on a fresh install
+- [x] TASK-42.10.8 — Android: Run the regression checklist on a version upgrade
 - [ ] TASK-42.10.9 — After publish, quick recheck of the release content and core functions on iOS App Store production
 - [ ] TASK-42.10.10 — After publish, quick recheck of the release content and core functions on Android Google Play production
-- [ ] TASK-42.10.11 — Log any bugs found, tag with platform and stage (iOS/Android × beta/production)
+- [x] TASK-42.10.11 — Log any bugs found, tag with platform and stage (iOS/Android × beta/production)
 
 ## Bugs found
 
-Not tested yet.
+None found on iOS TestFlight or Android Google Play beta stages.
 
 ## Test notes
 
-- **Tested on**: not tested yet
+- **Tested on**: iOS TestFlight, Android Google Play beta — both pass. iOS App Store / Android Google Play production not tested yet.
 - **Environment**: iOS TestFlight / Android Google Play beta → iOS App Store / Android Google Play production
-- **Passed**: pending
+- **Passed**: 4 / 6 AC (beta stages); production stages pending
 
 ## Retest
 
-N/A — not tested yet.
+N/A — no bugs found on beta stages. Production stages still to be done.
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary
- US-42.10 (Mobile release v1.2.xx): mark iOS TestFlight and Android Google Play beta stages as passed (4/6 AC, regression checklist all pass across fresh install + upgrade). Production stages (AC-5/6, TASK-42.10.9/10) still pending.
- Fill in the `commit:` frontmatter field with the story's own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected