### PR TITLE
docs: close US-42.10 (mobile v1.2.44(532)b-v16), update EPIC-42 row

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -42,7 +42,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.6](../stories/US-42.6-qc-release-extension-v1-3-84.md) | Release extension v1.3.84 — dev, master, draft, production gate | done |
 | [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — PR test, all 3 platforms (#5024) | done |
 | [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | done |
-| [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-xx.md) | Release Mobile v1.2.xx(xxx)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | ready |
+| [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md) | Release Mobile v1.2.44(532)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | done |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md
+++ b/docs/sprints/stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped: 1.2.44(532)b-v16
 prd_ref: []
 assignee: 
-commit: 9173b80b9f
+commit: 9173b80b9f, bb1c865243
 created: 2026-07-22
 updated: 2026-07-22
 ---

--- a/docs/sprints/stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md
+++ b/docs/sprints/stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md
@@ -1,12 +1,12 @@
 ---
 id: US-42.10
-title: "QC — Release SubWallet Mobile v1.2.xx(xxx)b-v16"
+title: "QC — Release SubWallet Mobile v1.2.44(532)b-v16"
 epic: EPIC-42
-status: in-progress
+status: done
 priority: P2
 points: 8
 sprint: sprint-2026-W30
-version_shipped:
+version_shipped: 1.2.44(532)b-v16
 prd_ref: []
 assignee: 
 commit: 9173b80b9f
@@ -14,15 +14,15 @@ created: 2026-07-22
 updated: 2026-07-22
 ---
 
-> **Version placeholder**: `v1.2.xx(xxx)b-v16` is a temporary version string. Confirm and update it before this story is marked done.
+> **Version**: v1.2.44(532)b-v16
 
 ## Goal
 
-QC the Mobile v1.2.xx(xxx)b-v16 release end to end on both iOS and Android: verify the release content works on the beta build (with fresh install + upgrade regression), then quick-check the production build after it ships.
+QC the Mobile v1.2.44(532)b-v16 release end to end on both iOS and Android: verify the release content works on the beta build (with fresh install + upgrade regression), then quick-check the production build after it ships.
 
 ## Background
 
-Release content for v1.2.xx(xxx)b-v16:
+Release content for v1.2.44(532)b-v16:
 
 - [Mobile] Add recommend validator for native and subnet staking ([#5024](https://github.com/Koniverse/SubWallet-Extension/issues/5024))
 
@@ -41,8 +41,8 @@ This is the Mobile counterpart to the same feature already QC'd on Extension ([U
 - [x] AC-2: Regression pass on iOS TestFlight finds no new issues, on both fresh install and upgrade (see Regression checklist)
 - [x] AC-3: Recommend validator (#5024) works correctly on the Android Google Play beta build
 - [x] AC-4: Regression pass on Android Google Play beta finds no new issues, on both fresh install and upgrade (see Regression checklist)
-- [ ] AC-5: Quick recheck on iOS App Store production confirms the release content is live and working, no critical issues
-- [ ] AC-6: Quick recheck on Android Google Play production confirms the release content is live and working, no critical issues
+- [x] AC-5: Quick recheck on iOS App Store production confirms the release content is live and working, no critical issues
+- [x] AC-6: Quick recheck on Android Google Play production confirms the release content is live and working, no critical issues
 
 ## Regression checklist (main functions)
 
@@ -69,23 +69,23 @@ Run this list on each beta stage (iOS TestFlight, Android Google Play beta), on 
 - [x] TASK-42.10.6 — Android: Verify recommend validator feature on Google Play beta (link to US-42.7 for detailed steps)
 - [x] TASK-42.10.7 — Android: Run the regression checklist on a fresh install
 - [x] TASK-42.10.8 — Android: Run the regression checklist on a version upgrade
-- [ ] TASK-42.10.9 — After publish, quick recheck of the release content and core functions on iOS App Store production
-- [ ] TASK-42.10.10 — After publish, quick recheck of the release content and core functions on Android Google Play production
+- [x] TASK-42.10.9 — After publish, quick recheck of the release content and core functions on iOS App Store production
+- [x] TASK-42.10.10 — After publish, quick recheck of the release content and core functions on Android Google Play production
 - [x] TASK-42.10.11 — Log any bugs found, tag with platform and stage (iOS/Android × beta/production)
 
 ## Bugs found
 
-None found on iOS TestFlight or Android Google Play beta stages.
+None found on any stage.
 
 ## Test notes
 
-- **Tested on**: iOS TestFlight, Android Google Play beta — both pass. iOS App Store / Android Google Play production not tested yet.
+- **Tested on**: iOS TestFlight, Android Google Play beta, iOS App Store, Android Google Play — all pass.
 - **Environment**: iOS TestFlight / Android Google Play beta → iOS App Store / Android Google Play production
-- **Passed**: 4 / 6 AC (beta stages); production stages pending
+- **Passed**: 6 / 6 AC
 
 ## Retest
 
-N/A — no bugs found on beta stages. Production stages still to be done.
+N/A — no bugs found on any stage.
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary
- Close US-42.10 — Mobile release v1.2.44(532)b-v16 release gate complete, all 6 AC pass across all 4 stages (iOS TestFlight, Android Google Play beta, iOS App Store, Android Google Play), no bugs found. Update version string from placeholder `v1.2.xx(xxx)b-v16` to real `v1.2.44(532)b-v16` (also in file path, title, body).
- Sync EPIC-42 QA tracking table: update US-42.10 row to point at new file path and `done` status.
- Fill in the `commit:` frontmatter field with the story's own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected