### PR TITLE
docs: add US-42.11 QC for PR #5043 + #5045 on Extension

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -43,6 +43,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — PR test, all 3 platforms (#5024) | done |
 | [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | done |
 | [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md) | Release Mobile v1.2.44(532)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | done |
+| [US-42.11](../stories/US-42.11-qc-extension-pr5043-and-issue5045.md) | Extension: PR #5043 signing prompt security fix + #5045 Bittensor deprecated function removal | ready |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/stories/US-42.11-qc-extension-pr5043-and-issue5045.md
+++ b/docs/sprints/stories/US-42.11-qc-extension-pr5043-and-issue5045.md
@@ -1,0 +1,73 @@
+---
+id: US-42.11
+title: "QC — Extension: PR #5043 (signing prompt security fix) + #5045 (Bittensor deprecated root claim type removal)"
+epic: EPIC-42
+status: ready
+priority: P2
+points: 5
+sprint: sprint-2026-W30
+version_shipped:
+prd_ref: []
+assignee: 
+commit:
+created: 2026-07-22
+updated: 2026-07-22
+---
+
+## Goal
+
+Verify two PR-level fixes on the **Extension** (this story is PR-level test, not a release — Web App and Mobile are tracked separately if needed):
+
+1. **PR #5043** — Security fix for [issue #5042](https://github.com/Koniverse/SubWallet-Extension/issues/5042): reject signing prompts that could conceal the actual transaction details from users.
+2. **Issue #5045** — Remove the deprecated Bittensor root claim type function, deprecated after Bittensor v4.4.1 upgrade ([release notes](https://www.bittensor.com/releases/v441-upgrade)). Reference PR: #5046.
+
+Both items must work correctly across fresh install and version upgrade.
+
+## Background
+
+- **PR #5043** is a security fix in the signing flow — malicious dApps can no longer hide the real transaction payload behind a misleading prompt. Covers [Issue #5042](https://github.com/Koniverse/SubWallet-Extension/issues/5042).
+- **Issue #5045** cleans up a deprecated function in the Bittensor earning feature so the extension stays compatible with v4.4.1 of the chain.
+
+This is a PR-level check, not a release. Web App and Mobile ship and release on their own schedule, separate from Extension — they get a separate story when that testing starts (one per platform) so release gates stay independent. See [US-42.6](US-42.6-qc-release-extension-v1-3-84.md) for the Extension release gate template.
+
+## Acceptance criteria
+
+- [ ] **AC-1**: When a dApp triggers a signing prompt that would conceal the actual transaction details, the Extension rejects the prompt and warns the user (no signature sent).
+- [ ] **AC-2**: When a dApp triggers a normal/legit signing prompt, the Extension still shows the true transaction details and signs as expected (no regression).
+- [ ] **AC-3**: The deprecated Bittensor root claim type function is removed from the Extension — no crashes, no leftover references that break the earning UI.
+- [ ] **AC-4**: Existing Bittensor earning flows (stake/unstake/claim on supported networks) still work after the deprecated function is removed.
+- [ ] **AC-5**: AC-1 to AC-4 work smoothly on the Extension without UI glitches or crashes.
+- [ ] **AC-6**: The changes behave correctly on a fresh install of the Extension.
+- [ ] **AC-7**: The changes behave correctly on a version upgrade of the Extension (existing accounts and data are preserved).
+
+## Tasks
+
+- [ ] TASK-42.11.1 — Test that a signing prompt designed to conceal the transaction payload is rejected on the Extension.
+- [ ] TASK-42.11.2 — Test that a legitimate signing prompt still works end-to-end on the Extension (no false positives).
+- [ ] TASK-11.3 — Verify the deprecated Bittensor root claim type function is gone from the Extension code and does not break the earning UI.
+- [ ] TASK-42.11.4 — Run Bittensor earning flows (stake/unstake/claim where applicable) to confirm no regression.
+- [ ] TASK-42.11.5 — Repeat AC-1 to AC-4 on a version upgrade (existing accounts + data preserved).
+- [ ] TASK-42.11.6 — Log any bugs found.
+
+## Bugs found
+
+Not tested yet.
+
+## Test notes
+
+- **Tested on**: not tested yet
+- **Environment**: PR build / Staging
+- **Passed**: 0 / 7 AC
+
+## Retest
+
+N/A — not tested yet.
+
+## Cross-references
+
+- [PR #5043](https://github.com/Koniverse/SubWallet-Extension/pull/5043) — signing prompt security fix
+- [Issue #5042](https://github.com/Koniverse/SubWallet-Extension/issues/5042) — vulnerability behind PR #5043
+- [Issue #5045](https://github.com/Koniverse/SubWallet-Extension/issues/5045) — remove deprecated Bittensor root claim type function
+- [PR #5046](https://github.com/Koniverse/SubWallet-Extension/pull/5046) — reference implementation for #5045
+- [US-42.7](US-42.7-qc-recommend-validator-native-subnet-staking.md) — same PR-level QC format
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/sprints/stories/US-42.11-qc-extension-pr5043-and-issue5045.md
+++ b/docs/sprints/stories/US-42.11-qc-extension-pr5043-and-issue5045.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit:
+commit: 4b5c85cc82
 created: 2026-07-22
 updated: 2026-07-22
 ---


### PR DESCRIPTION
## Summary
- Add QC story US-42.11 combining PR #5043 (signing prompt security fix for #5042) and Issue #5045 (Bittensor deprecated root claim type removal) — Extension only, PR-level test.
- Update EPIC-42 QA tracking page to list US-42.11.
- Fill in the `commit:` frontmatter field with the story's own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected