### PR TITLE
docs: update US-42.11 (Bittensor pass) + close US-42.12 (Web App PR #5043)

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -44,7 +44,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | done |
 | [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md) | Release Mobile v1.2.44(532)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | done |
 | [US-42.11](../stories/US-42.11-qc-extension-pr5043-and-issue5045.md) | Extension: PR #5043 signing prompt security fix + #5045 Bittensor deprecated function removal | in-progress |
-| [US-42.12](../stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md) | Web App: PR #5043 signing prompt security fix (#5042) | ready |
+| [US-42.12](../stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md) | Web App: PR #5043 signing prompt security fix (#5042) | done |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -43,7 +43,8 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.7](../stories/US-42.7-qc-recommend-validator-native-subnet-staking.md) | Recommend validator for native/subnet staking — PR test, all 3 platforms (#5024) | done |
 | [US-42.9](../stories/US-42.9-qc-release-webapp-v1-3-56-0.md) | Release Web App v1.3.56-0 (1356-0014) — recommend validator (#5024), dev/production gate | done |
 | [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md) | Release Mobile v1.2.44(532)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | done |
-| [US-42.11](../stories/US-42.11-qc-extension-pr5043-and-issue5045.md) | Extension: PR #5043 signing prompt security fix + #5045 Bittensor deprecated function removal | ready |
+| [US-42.11](../stories/US-42.11-qc-extension-pr5043-and-issue5045.md) | Extension: PR #5043 signing prompt security fix + #5045 Bittensor deprecated function removal | in-progress |
+| [US-42.12](../stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md) | Web App: PR #5043 signing prompt security fix (#5042) | ready |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/stories/US-42.11-qc-extension-pr5043-and-issue5045.md
+++ b/docs/sprints/stories/US-42.11-qc-extension-pr5043-and-issue5045.md
@@ -2,7 +2,7 @@
 id: US-42.11
 title: "QC — Extension: PR #5043 (signing prompt security fix) + #5045 (Bittensor deprecated root claim type removal)"
 epic: EPIC-42
-status: ready
+status: in-progress
 priority: P2
 points: 5
 sprint: sprint-2026-W30
@@ -34,34 +34,34 @@ This is a PR-level check, not a release. Web App and Mobile ship and release on 
 
 - [ ] **AC-1**: When a dApp triggers a signing prompt that would conceal the actual transaction details, the Extension rejects the prompt and warns the user (no signature sent).
 - [ ] **AC-2**: When a dApp triggers a normal/legit signing prompt, the Extension still shows the true transaction details and signs as expected (no regression).
-- [ ] **AC-3**: The deprecated Bittensor root claim type function is removed from the Extension — no crashes, no leftover references that break the earning UI.
-- [ ] **AC-4**: Existing Bittensor earning flows (stake/unstake/claim on supported networks) still work after the deprecated function is removed.
-- [ ] **AC-5**: AC-1 to AC-4 work smoothly on the Extension without UI glitches or crashes.
-- [ ] **AC-6**: The changes behave correctly on a fresh install of the Extension.
-- [ ] **AC-7**: The changes behave correctly on a version upgrade of the Extension (existing accounts and data are preserved).
+- [x] **AC-3**: The deprecated Bittensor root claim type function is removed from the Extension — no crashes, no leftover references that break the earning UI. _(verified on Extension)_
+- [x] **AC-4**: Existing Bittensor earning flows (stake/unstake/claim on supported networks) still work after the deprecated function is removed. _(verified on Extension)_
+- [ ] **AC-5**: AC-1 to AC-4 work smoothly on the Extension without UI glitches or crashes. — pending signing-prompt (AC-1/AC-2) testing
+- [ ] **AC-6**: The changes behave correctly on a fresh install of the Extension. — pending signing-prompt (AC-1/AC-2) testing
+- [ ] **AC-7**: The changes behave correctly on a version upgrade of the Extension (existing accounts and data are preserved). — pending signing-prompt (AC-1/AC-2) testing
 
 ## Tasks
 
 - [ ] TASK-42.11.1 — Test that a signing prompt designed to conceal the transaction payload is rejected on the Extension.
 - [ ] TASK-42.11.2 — Test that a legitimate signing prompt still works end-to-end on the Extension (no false positives).
-- [ ] TASK-11.3 — Verify the deprecated Bittensor root claim type function is gone from the Extension code and does not break the earning UI.
-- [ ] TASK-42.11.4 — Run Bittensor earning flows (stake/unstake/claim where applicable) to confirm no regression.
-- [ ] TASK-42.11.5 — Repeat AC-1 to AC-4 on a version upgrade (existing accounts + data preserved).
-- [ ] TASK-42.11.6 — Log any bugs found.
+- [x] TASK-11.3 — Verify the deprecated Bittensor root claim type function is gone from the Extension code and does not break the earning UI.
+- [x] TASK-42.11.4 — Run Bittensor earning flows (stake/unstake/claim where applicable) to confirm no regression.
+- [ ] TASK-42.11.5 — Repeat AC-1 to AC-4 on a version upgrade (existing accounts + data preserved). — pending signing-prompt (AC-1/AC-2) testing
+- [x] TASK-42.11.6 — Log any bugs found.
 
 ## Bugs found
 
-Not tested yet.
+None found on Bittensor deprecated function removal.
 
 ## Test notes
 
-- **Tested on**: not tested yet
+- **Tested on**: Extension — Bittensor deprecated function removal (Issue #5045) pass. PR #5043 signing prompt security not tested yet.
 - **Environment**: PR build / Staging
-- **Passed**: 0 / 7 AC
+- **Passed**: 2 / 7 AC (Bittensor #5045 only); signing-prompt (#5043) testing pending
 
 ## Retest
 
-N/A — not tested yet.
+N/A — no bugs found on Bittensor. Signing-prompt testing still to be done.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.11-qc-extension-pr5043-and-issue5045.md
+++ b/docs/sprints/stories/US-42.11-qc-extension-pr5043-and-issue5045.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit: 4b5c85cc82
+commit: 4b5c85cc82, 8ba53fdd72
 created: 2026-07-22
 updated: 2026-07-22
 ---

--- a/docs/sprints/stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md
+++ b/docs/sprints/stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit:
+commit: caa9ba1f27
 created: 2026-07-22
 updated: 2026-07-22
 ---

--- a/docs/sprints/stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md
+++ b/docs/sprints/stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W30
 version_shipped:
 prd_ref: []
 assignee: 
-commit: caa9ba1f27
+commit: caa9ba1f27, 422a391923
 created: 2026-07-22
 updated: 2026-07-22
 ---

--- a/docs/sprints/stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md
+++ b/docs/sprints/stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md
@@ -1,0 +1,61 @@
+---
+id: US-42.12
+title: "QC — Web App: PR #5043 (signing prompt security fix for #5042)"
+epic: EPIC-42
+status: ready
+priority: P2
+points: 3
+sprint: sprint-2026-W30
+version_shipped:
+prd_ref: []
+assignee: 
+commit:
+created: 2026-07-22
+updated: 2026-07-22
+---
+
+## Goal
+
+Verify the Web App side of the [PR #5043](https://github.com/Koniverse/SubWallet-Extension/pull/5043) security fix — reject signing prompts that could conceal the actual transaction details from users ([Issue #5042](https://github.com/Koniverse/SubWallet-Extension/issues/5042)). The change must work correctly across fresh install and version upgrade.
+
+## Background
+
+- [PR #5043](https://github.com/Koniverse/SubWallet-Extension/pull/5043) is a security fix in the signing flow — malicious dApps can no longer hide the real transaction payload behind a misleading prompt. Covers [Issue #5042](https://github.com/Koniverse/SubWallet-Extension/issues/5042).
+- This story is the **Web App counterpart** of the same feature already QC'd on Extension in [US-42.11](US-42.11-qc-extension-pr5043-and-issue5045.md). Only the PR #5043 part (signing prompt security) is in scope here — Issue #5045 is Bittensor-specific and not relevant to Web App.
+- Web App ships on its own release schedule, separate from Extension and Mobile. This is a PR-level test, not a release gate; a separate release-gate story is created when the Web App version ships.
+
+## Acceptance criteria
+
+- [ ] **AC-1**: When a dApp triggers a signing prompt that would conceal the actual transaction details, the Web App rejects the prompt and warns the user (no signature sent).
+- [ ] **AC-2**: When a dApp triggers a normal/legit signing prompt, the Web App still shows the true transaction details and signs as expected (no regression).
+- [ ] **AC-3**: AC-1 to AC-2 work smoothly on the Web App without UI glitches or crashes.
+- [ ] **AC-4**: The change behaves correctly on a fresh install of the Web App.
+- [ ] **AC-5**: The change behaves correctly on a version upgrade of the Web App (existing accounts and data are preserved).
+
+## Tasks
+
+- [ ] TASK-42.12.1 — Test that a signing prompt designed to conceal the transaction payload is rejected on the Web App.
+- [ ] TASK-42.12.2 — Test that a legitimate signing prompt still works end-to-end on the Web App (no false positives).
+- [ ] TASK-42.12.3 — Repeat AC-1 and AC-2 on a version upgrade (existing accounts + data preserved).
+- [ ] TASK-42.12.4 — Log any bugs found.
+
+## Bugs found
+
+Not tested yet.
+
+## Test notes
+
+- **Tested on**: not tested yet
+- **Environment**: PR build / Staging
+- **Passed**: 0 / 5 AC
+
+## Retest
+
+N/A — not tested yet.
+
+## Cross-references
+
+- [PR #5043](https://github.com/Koniverse/SubWallet-Extension/pull/5043) — signing prompt security fix
+- [Issue #5042](https://github.com/Koniverse/SubWallet-Extension/issues/5042) — vulnerability behind PR #5043
+- [US-42.11](US-42.11-qc-extension-pr5043-and-issue5045.md) — same feature QC on Extension
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/sprints/stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md
+++ b/docs/sprints/stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md
@@ -2,7 +2,7 @@
 id: US-42.12
 title: "QC — Web App: PR #5043 (signing prompt security fix for #5042)"
 epic: EPIC-42
-status: ready
+status: done
 priority: P2
 points: 3
 sprint: sprint-2026-W30
@@ -26,32 +26,32 @@ Verify the Web App side of the [PR #5043](https://github.com/Koniverse/SubWallet
 
 ## Acceptance criteria
 
-- [ ] **AC-1**: When a dApp triggers a signing prompt that would conceal the actual transaction details, the Web App rejects the prompt and warns the user (no signature sent).
-- [ ] **AC-2**: When a dApp triggers a normal/legit signing prompt, the Web App still shows the true transaction details and signs as expected (no regression).
-- [ ] **AC-3**: AC-1 to AC-2 work smoothly on the Web App without UI glitches or crashes.
-- [ ] **AC-4**: The change behaves correctly on a fresh install of the Web App.
-- [ ] **AC-5**: The change behaves correctly on a version upgrade of the Web App (existing accounts and data are preserved).
+- [x] **AC-1**: When a dApp triggers a signing prompt that would conceal the actual transaction details, the Web App rejects the prompt and warns the user (no signature sent).
+- [x] **AC-2**: When a dApp triggers a normal/legit signing prompt, the Web App still shows the true transaction details and signs as expected (no regression).
+- [x] **AC-3**: AC-1 to AC-2 work smoothly on the Web App without UI glitches or crashes.
+- [x] **AC-4**: The change behaves correctly on a fresh install of the Web App.
+- [x] **AC-5**: The change behaves correctly on a version upgrade of the Web App (existing accounts and data are preserved).
 
 ## Tasks
 
-- [ ] TASK-42.12.1 — Test that a signing prompt designed to conceal the transaction payload is rejected on the Web App.
-- [ ] TASK-42.12.2 — Test that a legitimate signing prompt still works end-to-end on the Web App (no false positives).
-- [ ] TASK-42.12.3 — Repeat AC-1 and AC-2 on a version upgrade (existing accounts + data preserved).
-- [ ] TASK-42.12.4 — Log any bugs found.
+- [x] TASK-42.12.1 — Test that a signing prompt designed to conceal the transaction payload is rejected on the Web App.
+- [x] TASK-42.12.2 — Test that a legitimate signing prompt still works end-to-end on the Web App (no false positives).
+- [x] TASK-42.12.3 — Repeat AC-1 and AC-2 on a version upgrade (existing accounts + data preserved).
+- [x] TASK-42.12.4 — Log any bugs found.
 
 ## Bugs found
 
-Not tested yet.
+None found.
 
 ## Test notes
 
-- **Tested on**: not tested yet
+- **Tested on**: Web App — pass.
 - **Environment**: PR build / Staging
-- **Passed**: 0 / 5 AC
+- **Passed**: 5 / 5 AC
 
 ## Retest
 
-N/A — not tested yet.
+N/A — no bugs found.
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary
- US-42.11 (Extension): mark Bittensor deprecated function removal (#5045) as passed on Extension — 2/7 AC pass; signing prompt security (#5043) testing still pending.
- US-42.12 (Web App): close story — PR #5043 signing prompt security all 5 AC pass on Web App, no bugs found.
- Sync EPIC-42 QA tracking table: US-42.11 → in-progress, US-42.12 → done.
- Fill in the `commit:` frontmatter fields for both stories with their own QC-doc commit hashes.

## Test plan
- [ ] Docs-only change, no code affected