### PR TITLE
qc: close US-42.13 (Gavun's Grid Miner dApp, #5050), all 8 AC pass

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -45,6 +45,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md) | Release Mobile v1.2.44(532)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | done |
 | [US-42.11](../stories/US-42.11-qc-extension-pr5043-and-issue5045.md) | Extension: PR #5043 signing prompt security fix + #5045 Bittensor deprecated function removal | done |
 | [US-42.12](../stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md) | Web App: PR #5043 signing prompt security fix (#5042) | done |
+| [US-42.13](../stories/US-42.13-qc-issue-5050-gavuns-grid-miner-dapp.md) | Gavun's Grid Miner dApp added to dApp list (#5050) — Web App + Mobile, dev → production | ready |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -45,7 +45,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.10](../stories/US-42.10-qc-release-mobile-v1-2-44-532-b-v16.md) | Release Mobile v1.2.44(532)b-v16 — recommend validator (#5024), iOS/Android beta+production gate | done |
 | [US-42.11](../stories/US-42.11-qc-extension-pr5043-and-issue5045.md) | Extension: PR #5043 signing prompt security fix + #5045 Bittensor deprecated function removal | done |
 | [US-42.12](../stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md) | Web App: PR #5043 signing prompt security fix (#5042) | done |
-| [US-42.13](../stories/US-42.13-qc-issue-5050-gavuns-grid-miner-dapp.md) | Gavun's Grid Miner dApp added to dApp list (#5050) — Web App + Mobile, dev → production | ready |
+| [US-42.13](../stories/US-42.13-qc-issue-5050-gavuns-grid-miner-dapp.md) | Gavun's Grid Miner dApp added to dApp list (#5050) — Web App + Mobile, dev → production | done |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/stories/US-42.13-qc-issue-5050-gavuns-grid-miner-dapp.md
+++ b/docs/sprints/stories/US-42.13-qc-issue-5050-gavuns-grid-miner-dapp.md
@@ -2,16 +2,16 @@
 id: US-42.13
 title: "QC — Gavun's Grid Miner dApp added to SubWallet dApp list (#5050)"
 epic: EPIC-42
-status: ready
+status: done
 priority: P3
 points: 3
-sprint: sprint-2026-W32
+sprint: sprint-2026-W33
 version_shipped:
 prd_ref: []
 assignee: MaiThuongNinni
 commit:
-created: 2026-08-05
-updated: 2026-08-05
+created: 2026-08-10
+updated: 2026-08-10
 ---
 
 ## Goal
@@ -42,41 +42,41 @@ Scope per user instruction: deploy first on **dev** environment, then on **produ
 
 ## Things to check
 
-- [ ] AC-1: Gavun's Grid Miner appears in the dApp list on Web App (dev), with correct name, logo, and category (gaming)
-- [ ] AC-2: Gavun's Grid Miner appears in the dApp list on Mobile (dev), with correct name, logo, and category (gaming)
-- [ ] AC-3: Tapping/clicking the dApp entry opens the link https://gavunminer.xyz/ correctly (webview/in-app browser)
-- [ ] AC-4: Connecting SubWallet to the dApp works on Web App (dev) — dApp can read the connected account
-- [ ] AC-5: Connecting SubWallet to the dApp works on Mobile (dev) — dApp can read the connected account
-- [ ] AC-6: AC-1 to AC-5 hold on a **fresh install** of each platform (no prior version/data)
-- [ ] AC-7: AC-1 to AC-5 hold on an **upgrade** of each platform (existing accounts/data carried over)
-- [ ] AC-8: AC-1 to AC-7 still hold on **production** environment for Web App and Mobile
+- [x] AC-1: Gavun's Grid Miner appears in the dApp list on Web App (dev), with correct name, logo, and category (gaming)
+- [x] AC-2: Gavun's Grid Miner appears in the dApp list on Mobile (dev), with correct name, logo, and category (gaming)
+- [x] AC-3: Tapping/clicking the dApp entry opens the link https://gavunminer.xyz/ correctly (webview/in-app browser)
+- [x] AC-4: Connecting SubWallet to the dApp works on Web App (dev) — dApp can read the connected account
+- [x] AC-5: Connecting SubWallet to the dApp works on Mobile (dev) — dApp can read the connected account
+- [x] AC-6: AC-1 to AC-5 hold on a **fresh install** of each platform (no prior version/data)
+- [x] AC-7: AC-1 to AC-5 hold on an **upgrade** of each platform (existing accounts/data carried over)
+- [x] AC-8: AC-1 to AC-7 still hold on **production** environment for Web App and Mobile
 
 ## Steps
 
-- [ ] TASK-42.13.1 — Confirm the dApp list update has landed in dev for Web App and Mobile (check the dApps JSON/version in use)
-- [ ] TASK-42.13.2 — Web App (dev): open the dApp list, confirm Gavun's Grid Miner shows correct name, logo, category
-- [ ] TASK-42.13.3 — Mobile (dev): open the dApp list, confirm Gavun's Grid Miner shows correct name, logo, category
-- [ ] TASK-42.13.4 — Open the dApp from the list, confirm it navigates to https://gavunminer.xyz/ on Web App and Mobile
-- [ ] TASK-42.13.5 — Connect SubWallet to the dApp, confirm the dApp can read the connected account on Web App
-- [ ] TASK-42.13.6 — Connect SubWallet to the dApp, confirm the dApp can read the connected account on Mobile
-- [ ] TASK-42.13.7 — Repeat TASK-42.13.2 to TASK-42.13.6 on a **fresh install** of each platform
-- [ ] TASK-42.13.8 — Repeat TASK-42.13.2 to TASK-42.13.6 on an **upgrade** of each platform
-- [ ] TASK-42.13.9 — Once deployed to production, repeat the dApp list entry + open + connect checks on Web App (prod) and Mobile (prod)
-- [ ] TASK-42.13.10 — Log any bugs found, tag with stage (dev / prod) and platform (Web App / Mobile)
+- [x] TASK-42.13.1 — Confirm the dApp list update has landed in dev for Web App and Mobile (check the dApps JSON/version in use)
+- [x] TASK-42.13.2 — Web App (dev): open the dApp list, confirm Gavun's Grid Miner shows correct name, logo, category
+- [x] TASK-42.13.3 — Mobile (dev): open the dApp list, confirm Gavun's Grid Miner shows correct name, logo, category
+- [x] TASK-42.13.4 — Open the dApp from the list, confirm it navigates to https://gavunminer.xyz/ on Web App and Mobile
+- [x] TASK-42.13.5 — Connect SubWallet to the dApp, confirm the dApp can read the connected account on Web App
+- [x] TASK-42.13.6 — Connect SubWallet to the dApp, confirm the dApp can read the connected account on Mobile
+- [x] TASK-42.13.7 — Repeat TASK-42.13.2 to TASK-42.13.6 on a **fresh install** of each platform
+- [x] TASK-42.13.8 — Repeat TASK-42.13.2 to TASK-42.13.6 on an **upgrade** of each platform
+- [x] TASK-42.13.9 — Once deployed to production, repeat the dApp list entry + open + connect checks on Web App (prod) and Mobile (prod)
+- [x] TASK-42.13.10 — Log any bugs found, tag with stage (dev / prod) and platform (Web App / Mobile)
 
 ## Bugs found
 
-Not tested yet.
+None.
 
 ## Test notes
 
-- **Tested on**: not tested yet
-- **Environment**: dev → production, on Web App + Mobile (iOS/Android)
-- **Passed**: pending
+- **Tested on**: Web App + Mobile (iOS/Android), both dev and production
+- **Environment**: dev → production
+- **Passed**: 8 / 8 AC
 
 ## Retest
 
-N/A — not tested yet.
+N/A — all AC passed on first test.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.13-qc-issue-5050-gavuns-grid-miner-dapp.md
+++ b/docs/sprints/stories/US-42.13-qc-issue-5050-gavuns-grid-miner-dapp.md
@@ -1,0 +1,84 @@
+---
+id: US-42.13
+title: "QC — Gavun's Grid Miner dApp added to SubWallet dApp list (#5050)"
+epic: EPIC-42
+status: ready
+priority: P3
+points: 3
+sprint: sprint-2026-W32
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-08-05
+updated: 2026-08-05
+---
+
+## Goal
+
+Verify the new dApp **Gavun's Grid Miner** is added correctly to the SubWallet dApp list and works end-to-end on **Web App** and **Mobile** (iOS/Android), on both **dev** and **production** environments.
+
+## Background
+
+This request comes from [issue #5050](https://github.com/Koniverse/SubWallet-Extension/issues/5050) — add a new dApp entry for **Gavun's Grid Miner** to the SubWallet dApp list.
+
+dApp info from the request:
+
+- dApp Name: Gavun's Grid Miner
+- dApp Link: https://gavunminer.xyz/
+- Brief: Mining game on Polkadot Asset Hub — free to play, break rock, open Mystery Boxes, collect skins that mint as real NFTs on Asset Hub. Holds of $WUD or $DED get stronger runs.
+- Logo: Figma link in the issue
+- Network: Polkadot Asset Hub
+- dApp Category: gaming
+- Feature dApp: No
+- Banner Preview: No
+
+Scope per user instruction: deploy first on **dev** environment, then on **production**, on **both Web App and Mobile**. Extension is not in scope (the user listed Web App and Mobile only).
+
+## Stages
+
+1. **Dev environment** — verify the dApp shows up and works on Web App and Mobile in dev.
+2. **Production environment** — after deploying to prod, verify again on Web App and Mobile.
+
+## Things to check
+
+- [ ] AC-1: Gavun's Grid Miner appears in the dApp list on Web App (dev), with correct name, logo, and category (gaming)
+- [ ] AC-2: Gavun's Grid Miner appears in the dApp list on Mobile (dev), with correct name, logo, and category (gaming)
+- [ ] AC-3: Tapping/clicking the dApp entry opens the link https://gavunminer.xyz/ correctly (webview/in-app browser)
+- [ ] AC-4: Connecting SubWallet to the dApp works on Web App (dev) — dApp can read the connected account
+- [ ] AC-5: Connecting SubWallet to the dApp works on Mobile (dev) — dApp can read the connected account
+- [ ] AC-6: AC-1 to AC-5 hold on a **fresh install** of each platform (no prior version/data)
+- [ ] AC-7: AC-1 to AC-5 hold on an **upgrade** of each platform (existing accounts/data carried over)
+- [ ] AC-8: AC-1 to AC-7 still hold on **production** environment for Web App and Mobile
+
+## Steps
+
+- [ ] TASK-42.13.1 — Confirm the dApp list update has landed in dev for Web App and Mobile (check the dApps JSON/version in use)
+- [ ] TASK-42.13.2 — Web App (dev): open the dApp list, confirm Gavun's Grid Miner shows correct name, logo, category
+- [ ] TASK-42.13.3 — Mobile (dev): open the dApp list, confirm Gavun's Grid Miner shows correct name, logo, category
+- [ ] TASK-42.13.4 — Open the dApp from the list, confirm it navigates to https://gavunminer.xyz/ on Web App and Mobile
+- [ ] TASK-42.13.5 — Connect SubWallet to the dApp, confirm the dApp can read the connected account on Web App
+- [ ] TASK-42.13.6 — Connect SubWallet to the dApp, confirm the dApp can read the connected account on Mobile
+- [ ] TASK-42.13.7 — Repeat TASK-42.13.2 to TASK-42.13.6 on a **fresh install** of each platform
+- [ ] TASK-42.13.8 — Repeat TASK-42.13.2 to TASK-42.13.6 on an **upgrade** of each platform
+- [ ] TASK-42.13.9 — Once deployed to production, repeat the dApp list entry + open + connect checks on Web App (prod) and Mobile (prod)
+- [ ] TASK-42.13.10 — Log any bugs found, tag with stage (dev / prod) and platform (Web App / Mobile)
+
+## Bugs found
+
+Not tested yet.
+
+## Test notes
+
+- **Tested on**: not tested yet
+- **Environment**: dev → production, on Web App + Mobile (iOS/Android)
+- **Passed**: pending
+
+## Retest
+
+N/A — not tested yet.
+
+## Cross-references
+
+- [Issue #5050](https://github.com/Koniverse/SubWallet-Extension/issues/5050) — request to add Gavun's Grid Miner to the dApp list
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/tests/test-reports/2026-08-10/report-manual.md
+++ b/docs/tests/test-reports/2026-08-10/report-manual.md
@@ -1,0 +1,41 @@
+# Manual Test Report — 2026-08-10
+
+Not tied to one epic — this covers today's test tasks only.
+
+| Field | Value |
+|---|---|
+| Date | 2026-08-10 |
+| Tester | MaiThuongNinni |
+| Environment | dev → production |
+| Runner | manual (web app + mobile) |
+| Build under test | Koniverse/SubWallet-Extension @ koni-qc-epic42-sync |
+| Tasks tested | US-42.13 |
+| Total bugs found | 0 |
+| P0 | 0 |
+| P1 | 0 |
+| P2 | 0 |
+| Status | done |
+
+---
+
+## US-42.13 — Gavun's Grid Miner dApp added to SubWallet dApp list ([#5050](https://github.com/Koniverse/SubWallet-Extension/issues/5050))
+
+Tested on Web App + Mobile (iOS/Android), on both **dev** and **production**, including fresh install and upgrade.
+
+### Bugs
+
+None found. All checks passed:
+
+- Gavun's Grid Miner appears in the dApp list on both Web App and Mobile with the correct name, logo, and category (gaming).
+- Tapping the entry opens https://gavunminer.xyz/ correctly.
+- Connecting SubWallet to the dApp works on both platforms — dApp can read the connected account.
+- All of the above hold on a fresh install and on an upgrade.
+- All of the above hold again on the production deployment.
+
+---
+
+## Summary
+
+| Task | Bugs found | Status |
+|---|---|---|
+| US-42.13 | 0 | done |


### PR DESCRIPTION
## Summary
- **US-42.13**: Gavun's Grid Miner dApp added to SubWallet dApp list (#5050). Tested on Web App + Mobile (iOS/Android), on dev then production, including fresh install and upgrade. All 8 AC pass, no bugs. Status -> done.
- Adds today's manual test report (2026-08-10).
- EPIC-42 table: US-42.13 row -> done.

## Test plan
- [x] US-42.13 AC-1 to AC-8 verified on dev + production, Web App + Mobile, fresh install + upgrade
- [x] No bugs found