### PR TITLE
qc: add US-42.14 (DOT nomination pool unstake 28d -> 2d, #5055)

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -46,6 +46,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.11](../stories/US-42.11-qc-extension-pr5043-and-issue5045.md) | Extension: PR #5043 signing prompt security fix + #5045 Bittensor deprecated function removal | done |
 | [US-42.12](../stories/US-42.12-qc-webapp-pr5043-signing-prompt-security.md) | Web App: PR #5043 signing prompt security fix (#5042) | done |
 | [US-42.13](../stories/US-42.13-qc-issue-5050-gavuns-grid-miner-dapp.md) | Gavun's Grid Miner dApp added to dApp list (#5050) — Web App + Mobile, dev → production | done |
+| [US-42.14](../stories/US-42.14-qc-issue-5055-nominator-unstaking-eras-dot-2-days.md) | DOT nomination pool unstake period 28d → 2d (#5055); stake/unstake recheck | done |
 
 More rows get added here as testing starts.
 

--- a/docs/sprints/stories/US-42.14-qc-issue-5055-nominator-unstaking-eras-dot-2-days.md
+++ b/docs/sprints/stories/US-42.14-qc-issue-5055-nominator-unstaking-eras-dot-2-days.md
@@ -1,0 +1,60 @@
+---
+id: US-42.14
+title: "QC — Update nominator unstaking eras for DOT nomination pool (#5055)"
+epic: EPIC-42
+status: done
+priority: P2
+points: 2
+sprint: sprint-2026-W33
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-08-12
+updated: 2026-08-12
+---
+
+## Goal
+
+Verify the nominator unstaking period for **DOT nomination pool** is updated from **28 days** down to **2 days**, and re-check the stake / unstake flows still work end-to-end.
+
+## Background
+
+This request comes from [issue #5055](https://github.com/Koniverse/SubWallet-Extension/issues/5055) — *"Update nominator unstaking eras"*. Scope per user: change the withdraw waiting period for DOT nomination pool from 28 days to 2 days, then re-check the stake/unstake features.
+
+## Things to check
+
+- [x] AC-1: On DOT nomination pool, the unstake/withdraw waiting period now shows **2 days** (down from 28 days).
+- [x] AC-2: The stake flow (nominate / join pool) still works end-to-end on DOT nomination pool.
+- [x] AC-3: The unstake flow (leave pool / withdraw) still works end-to-end on DOT nomination pool.
+- [x] AC-4: The unstake countdown / "withdraw available in" label matches the new 2-day window.
+- [x] AC-5: AC-1 to AC-4 hold on a **fresh install** of the Extension.
+- [x] AC-6: AC-1 to AC-4 hold on an **upgrade** of the Extension (existing accounts/data preserved).
+
+## Steps
+
+- [x] TASK-42.14.1 — Open DOT nomination pool stake screen, confirm the unstake period label now reads 2 days.
+- [x] TASK-42.14.2 — Stake a small amount into a DOT nomination pool, confirm the stake goes through.
+- [x] TASK-42.14.3 — Unstake / leave the pool, confirm the operation goes through and the "withdraw available in" countdown matches the new 2-day window.
+- [x] TASK-42.14.4 — Repeat TASK-42.14.1 to TASK-42.14.3 on a **fresh install** of the Extension.
+- [x] TASK-42.14.5 — Repeat TASK-42.14.1 to TASK-42.14.3 on an **upgrade** of the Extension.
+- [x] TASK-42.14.6 — Log any bugs found.
+
+## Bugs found
+
+None.
+
+## Test notes
+
+- **Tested on**: Extension (Chrome), fresh install + upgrade
+- **Environment**: PR build / Staging
+- **Passed**: 6 / 6 AC
+
+## Retest
+
+N/A — all AC passed on first test.
+
+## Cross-references
+
+- [Issue #5055](https://github.com/Koniverse/SubWallet-Extension/issues/5055) — Update nominator unstaking eras
+- Epic: [EPIC-42](../epics/EPIC-42.md)


### PR DESCRIPTION
## Summary
- Adds **US-42.14**: QC for issue #5055 — DOT nomination pool unstake waiting period updated from 28 days to 2 days.
- Stake and unstake flows rechecked on fresh install + upgrade, all 6 AC pass, no bugs. Status -> done.
- EPIC-42 table: US-42.14 row -> done.

## Test plan
- [x] US-42.14 AC-1 to AC-6 verified on fresh install and upgrade
- [x] No bugs found