### PR TITLE
qc: close US-42.20 (passkey login, #5058) 14/14, add US-42.21 (release v1.3.89)

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -1,10 +1,10 @@
 ---
 id: EPIC-42
 title: "QA Coverage Tracking"
-status: done
+status: in-progress
 prd_ref: []
 created: 2026-07-16
-updated: 2026-08-19
+updated: 2026-08-25
 ---
 
 ## Goal
@@ -52,17 +52,19 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.17](../stories/US-42.17-qc-issue-5051-paraspell-api-v2.md) | ParaSpell API v2 (#5051) — XCM regression QC; dev story is US-13.18 | done |
 | [US-42.18](../stories/US-42.18-qc-issue-705-remove-dropped-xcm-routes.md) | Remove XCM routes dropped in ParaSpell v2 (#705) | done |
 | [US-42.19](../stories/US-42.19-qc-release-extension-v1-3-88.md) | Release extension v1.3.88 — ParaSpell v2 (#5051) + chainlist (#708, #707, #705); dev, master, draft, production gate | done |
+| [US-42.20](../stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) | Biometric / passkey login (#5058) — PR #5061 build; 14 / 14 AC, no bugs | done |
+| [US-42.21](../stories/US-42.21-qc-release-extension-v1-3-89.md) | Release extension v1.3.89 — passkey login (#5058) + KAH↔PAH XCM refs (#5062) + Bittensor manual claim (#5064); dev, master, draft, production gate | ready |
 
 More rows get added here as testing starts.
 
 ## What this epic actually became — and the two holes it left
 
 > **The stated rule is not the practice.** "Each dev epic gets **one** QA page named
-> `US-42.<epic-number>`" describes a per-epic index. The 14 pages above are numbered
+> `US-42.<epic-number>`" describes a per-epic index. The 20 pages above are numbered
 > **sequentially** and are three different kinds of thing: per-issue QC (42.1–42.5, 42.7, 42.13,
-> 42.14, 42.15), per-release gate QC (42.6, 42.9, 42.10) and per-PR QC (42.11, 42.12). Neither the
+> 42.14, 42.15, 42.16, 42.17, 42.18, 42.20), per-release gate QC (42.6, 42.9, 42.10, 42.19, 42.21) and per-PR QC (42.11, 42.12). Neither the
 > naming nor the one-page-per-epic promise survived contact. Recorded, not "fixed" — renumbering
-> 14 pages to match a sentence would break every link to them, and the sentence is the cheaper
+> 20 pages to match a sentence would break every link to them, and the sentence is the cheaper
 > thing to change.
 
 **The sequence skips 8** — it runs 42.1…42.7, then 42.9. Nothing was deleted:

--- a/docs/sprints/sprint-2026-W35.md
+++ b/docs/sprints/sprint-2026-W35.md
@@ -13,10 +13,29 @@ goal: "Two open pull requests, both opened after v1.3.88 shipped. The P0 is #506
 | US-13.19 | Repoint KAH↔PAH USDt XCM refs — the route that trapped funds | EPIC-13 | **P0** | 5 | review | new | [link](stories/US-13.19-repoint-kah-pah-usdt-xcm-refs.md) |
 | US-5.16 | Biometric / passkey login for the extension | EPIC-5 | P3 | 8 | review | ← backlog | [link](stories/US-5.16-biometric-passkey-login.md) |
 | US-12.23 | Manual claim for Bittensor native staking | EPIC-12 | P2 | 5 | review | ← backlog | [link](stories/US-12.23-bittensor-manual-claim-native-staking.md) |
+| US-42.20 | QC — Biometric / passkey login (#5058) | EPIC-42 | P2 | 5 | done | new | [link](stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) |
+| US-42.21 | QC — Release SubWallet Extension v1.3.89 | EPIC-42 | P2 | 8 | ready | new | [link](stories/US-42.21-qc-release-extension-v1-3-89.md) |
 
-**3 stories · 18 points.** All three are open PRs with no merge yet, so **nothing here is `done`
-and nothing has a `version_shipped`.** Between them they carry **one review** — `saltict` on
-PR #5063; the other two have none.
+**5 stories · 31 points** — 3 dev stories (18 pts) and 2 QC stories (13 pts). The three dev stories
+are all open PRs with no merge yet, so **none of them is `done` and none has a `version_shipped`.**
+Between them they carry **one review** — `saltict` on PR #5063; the other two have none.
+
+The one `done` in this window is a QC story, not a dev story: US-42.20 passed against a PR build.
+**Nothing has shipped.**
+
+The two QC stories were added on 2026-08-25 alongside the dev stories, not after them:
+[US-42.20](stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) covers the passkey feature —
+**`done` 2026-08-25, 14 / 14 AC, no bugs**, run against PR #5061 at commit `cab8ebd5ee`. Because
+that commit is **not merged**, the result is a claim about that build and not about whatever
+eventually lands; the release gate re-verifies rather than inherits it.
+
+[US-42.21](stories/US-42.21-qc-release-extension-v1-3-89.md) is the v1.3.89 release gate and **has
+not run** — there is no v1.3.89 tag, `VERSION` is at 1.3.88, and all three content PRs are still
+open. It stays `ready` until a build exists.
+
+One gap that follows from the table: the **P0** (US-13.19) and the Bittensor claim (US-12.23) have
+**no feature-level QC story**, only the release gate. The passkey item is the only one of the three
+with its own QC pass.
 
 Small again, and for the same reason [W34](sprint-2026-W34.md) was: this is what has evidence of
 being live. W34 closed at 5 of 5 on that basis.

--- a/docs/sprints/stories/US-42.20-qc-issue-5058-biometric-passkey-login.md
+++ b/docs/sprints/stories/US-42.20-qc-issue-5058-biometric-passkey-login.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W35
 version_shipped:
 prd_ref: []
 assignee: MaiThuongNinni
-commit:
+commit: fc91bb0462
 created: 2026-08-25
 updated: 2026-08-25
 ---

--- a/docs/sprints/stories/US-42.20-qc-issue-5058-biometric-passkey-login.md
+++ b/docs/sprints/stories/US-42.20-qc-issue-5058-biometric-passkey-login.md
@@ -1,0 +1,141 @@
+---
+id: US-42.20
+title: "QC — Support biometric/passkey login for extension (#5058)"
+epic: EPIC-42
+status: done
+priority: P2
+points: 5
+sprint: sprint-2026-W35
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-08-25
+updated: 2026-08-25
+---
+
+## Goal
+
+Test the new biometric / passkey login on the Extension — that the user can turn it on, unlock the wallet with it, and that the master password still works as a fallback in every case where the passkey is not available.
+
+## Background
+
+This story covers [issue #5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058) — *"Support biometric/passkey login for extension"*.
+
+The issue itself is a **title with an empty body** — no description, no acceptance criteria. So the checks below are derived from the code in the open PR, not from a written spec. If the developer writes requirements later, this story has to be re-read against them.
+
+| | |
+| --- | --- |
+| Issue | [#5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058) — OPEN, opened 2026-08-13 by `tunghp2002` |
+| PR | [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061) — OPEN, `koni/dev/issue-5058` → `subwallet-dev` |
+| Size | 6 commits, +1317 / −54, 20 files (checked 2026-08-25) |
+| Last commit | `cab8ebd5ee` *"Chore: update UI"*, 2026-08-25 |
+| Reviews | **none** |
+| Tests shipped | 2 spec files — `passkeyUnlock.spec.ts` in `extension-base` and in `extension-koni-ui` |
+
+> **The dev story [US-5.16](US-5.16-biometric-passkey-login.md) records this PR as 4 commits / 18 files / +1180 − 49.** That was true when it was written; two more commits have landed since (`0b7b248cfb` *"Fix bug UI in newest chrome version"* and `cab8ebd5ee` *"Chore: update UI"*). The numbers above are the current ones. Re-check before the run — this PR is still moving.
+
+### What the code actually does — it wraps the password, it does not replace it
+
+Read from the branch by the dev story, and it decides how this gets tested:
+
+`wrapWalletPassword()` AES-GCM-encrypts the **master password** under a key derived from the passkey **WebAuthn PRF extension** output, and stores only `{ciphertext, nonce, credential, input}`. The master password stays the root of custody; the passkey is a convenience layer in front of it.
+
+**That is the good outcome for testing** — it means the master password cannot be made unusable by the passkey, so the fallback checks below are verifying a path that exists in the code rather than hoping for one. It also means EPIC-5's *non-recoverable by design* rule is not reopened.
+
+**But it moves the main risk to browser support.** The feature depends on the **PRF extension**, whose browser coverage is narrower than passkeys in general — a browser can support passkeys and still not support PRF. So AC-10 is not a corner case: it is the likely everyday path on some browsers, and it has to be tested on a real browser that lacks PRF, not only by disabling the feature.
+
+**What the PR touches**, read from the file list — this is where the testing weight goes:
+
+- New passkey unlock logic: `passkeyUnlock.ts` in both `extension-base` (keyring service) and `extension-koni-ui`, with unit tests in both.
+- The unlock surfaces: the login screen (`Popup/Keyring/Login.tsx`), the unlock modal (`components/Modal/UnlockModal.tsx`), and the UI-lock hook (`hooks/common/useUILock.tsx`).
+- The setting to turn it on: `Popup/Settings/Security/index.tsx`.
+- The dApp / popup path: `request-service/handler/PopupHandler.ts` and `Popup/Root.tsx` — one commit is *"Update UI passkey for dApp"*, so the dApp signing prompt is in scope, not only the main unlock.
+- Copy in 5 languages (en, ja, ru, vi, zh).
+
+**This is a security-gate change.** A passkey is a new way past the lock that protects every private key in the wallet, so the negative cases matter as much as the happy path: if the passkey is removed, the device changes, or the browser has no authenticator, the master password must still open the wallet. A build that locks a user out of their own wallet is worse than one where the feature simply does not work.
+
+## Not in this story
+
+**The extension window flickering on open** (v1.3.88, macOS 26.4.1) is **out of scope** — someone else has already tested it. This story covers the passkey feature only.
+
+## Things to check
+
+**Turning it on**
+
+- [x] AC-1: The passkey / biometric option shows in Settings → Security, and is off by default
+- [x] AC-2: Turning it on asks for the master password first, then registers the passkey with the device
+- [x] AC-3: After it is on, the setting shows as on and survives closing and reopening the extension
+- [x] AC-4: Turning it off works, and after that the wallet asks for the master password again
+
+**Unlocking with it**
+
+- [x] AC-5: With it on, the login screen offers passkey unlock and a successful passkey opens the wallet
+- [x] AC-6: The unlock modal (the one shown before a transaction or a protected action) also accepts the passkey
+- [x] AC-7: Cancelling or failing the passkey prompt returns to the password screen with a clear message, no stuck screen
+- [x] AC-8: Auto-lock still works — after the wallet locks itself, the passkey unlocks it again
+
+**The fallback — the part that must not break**
+
+- [x] AC-9: The master password still unlocks the wallet at any time, with the passkey on
+- [x] AC-10: On a browser with **no WebAuthn PRF support** (passkeys alone are not enough — PRF is the part this feature needs), the wallet falls back to the master password cleanly: the passkey option is either hidden or fails with a clear message, and the user is never blocked
+- [x] AC-11: Removing the passkey from the device (or using a different profile) still leaves the wallet openable with the master password
+
+**dApp path**
+
+- [x] AC-12: Connecting to a dApp and signing a message or a transaction works with the passkey unlock in the flow, and the signing prompt shows the correct content
+- [x] AC-12b: The signature is produced over **exactly** what the prompt displayed — the passkey unlock in front of the confirm screen does not change or bypass what is signed (this is the rule [US-5.15](US-5.15-signing-prompt-mode-confusion.md) hardened after the #5042 security notice)
+
+**Install paths**
+
+- [x] AC-13: AC-1 to AC-12b hold on a **fresh install** (no prior version or data)
+- [x] AC-14: AC-1 to AC-12b hold on an **upgrade from v1.3.88** — existing accounts, settings and the existing master password all still work, and no account is lost
+
+## Steps
+
+- [x] TASK-42.20.1 — Confirm the PR #5061 build is the one under test, note the commit
+- [x] TASK-42.20.2 — Check the Security setting: default off, turn on, turn off (AC-1 to AC-4)
+- [x] TASK-42.20.3 — Unlock the wallet with the passkey from the login screen (AC-5)
+- [x] TASK-42.20.4 — Trigger the unlock modal from a transaction and unlock with the passkey (AC-6)
+- [x] TASK-42.20.5 — Cancel and fail the passkey prompt on purpose, check the message and that the password screen still works (AC-7)
+- [x] TASK-42.20.6 — Wait for auto-lock, then unlock with the passkey (AC-8)
+- [x] TASK-42.20.7 — With the passkey on, unlock with the master password instead (AC-9)
+- [x] TASK-42.20.8 — Test on a real browser without WebAuthn PRF support, confirm the password fallback and the message (AC-10)
+- [x] TASK-42.20.9 — Remove the passkey or switch profile, confirm the wallet still opens with the master password (AC-11)
+- [x] TASK-42.20.10 — Connect a dApp, sign a message and a transaction through the passkey flow, and check the signed payload matches what the prompt showed (AC-12, AC-12b)
+- [x] TASK-42.20.11 — Repeat TASK-42.20.2 to TASK-42.20.10 on a **fresh install** (AC-13)
+- [x] TASK-42.20.12 — Repeat them on an **upgrade from v1.3.88**, confirm accounts, settings and the master password all carried over (AC-14)
+- [x] TASK-42.20.13 — Run a short regression pass on the main unlock-related flows: create account, import account, send a token, export account
+- [x] TASK-42.20.14 — Log any bugs found in the manual test report
+
+## Bugs found
+
+None.
+
+## Test notes
+
+- **Tested on**: 2026-08-25 — Extension, fresh install + upgrade from v1.3.88
+- **Environment**: PR [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061) build, commit `cab8ebd5ee`
+- **Passed**: 14 / 14 AC (AC-1 to AC-14, including AC-12b)
+- **Full report**: [report-manual.md](../../tests/test-reports/2026-08-25/report-manual.md)
+
+The two checks worth recording separately, because they are the ones that could have gone badly:
+
+- **Master-password fallback holds** (AC-9, AC-10, AC-11). It still unlocks with the passkey enrolled, on a browser without WebAuthn PRF support, and after the passkey is removed. Nobody can be locked out of a wallet by this feature.
+- **dApp signing is unchanged** (AC-12, AC-12b). The signature is produced over exactly what the prompt displayed — the passkey unlock in front of the confirm screen does not alter or bypass the signed payload, so the [US-5.15](US-5.15-signing-prompt-mode-confusion.md) rule from #5042 still holds.
+
+## Retest
+
+N/A — all AC passed on the first run.
+
+**One caveat on the build.** This ran against `cab8ebd5ee` while PR #5061 was still open with **0 reviews**. If more commits land before it merges, the passkey paths need a re-run against the merged head — this result is a claim about the commit above, not about whatever merges later.
+
+## Cross-references
+
+- [Issue #5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058) — Support biometric/passkey login for extension
+- [PR #5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061) — the implementation under test
+- [US-5.16](US-5.16-biometric-passkey-login.md) — the dev-side story for the same issue, now `review` with code-derived AC (its AC-1 to AC-8 are the code-level claims; the AC here are the user-level checks)
+- [US-42.21](US-42.21-qc-release-extension-v1-3-89.md) — the v1.3.89 release gate this feeds into
+- [US-5.4](US-5.4-unified-unlock-and-auto-lock-flow.md) — the unified unlock flow this extends
+- [US-5.15](US-5.15-signing-prompt-mode-confusion.md) — earlier signing-prompt QC, same dApp path
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md
+++ b/docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md
@@ -1,0 +1,131 @@
+---
+id: US-42.21
+title: "QC — Release SubWallet Extension v1.3.89"
+epic: EPIC-42
+status: ready
+priority: P2
+points: 8
+sprint: sprint-2026-W35
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-08-25
+updated: 2026-08-25
+---
+
+## Goal
+
+QC the v1.3.89 release end to end, across every build stage from dev merge to production, checking both the release content and that nothing else broke (regression).
+
+## Background
+
+**The release is not cut yet.** `VERSION` is at **1.3.88** and the `v1.3.88` tag exists; there is no v1.3.89 tag or release branch as of 2026-08-25, and all three content PRs are still open. The content below is **planned**, read from the pull requests open against `subwallet-dev` right now — it is not a published release note. Re-check it against the real release note before the run starts, and update this story if an item drops out or a new one lands.
+
+Planned release content for v1.3.89:
+
+| Item | Issue | PR | Dev story | State on 2026-08-25 | Reviews | Tests in PR |
+| --- | --- | --- | --- | --- | --- | --- |
+| **P0** — Repoint KAH↔PAH USDt XCM refs | [#5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062) | [#5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) | [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) | open, `review` | 1 (`saltict`) | **none** |
+| Biometric / passkey login | [#5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058) | [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061) | [US-5.16](US-5.16-biometric-passkey-login.md) | open, 6 commits | **0** | 2 spec files |
+| Manual claim for Bittensor native staking | [#5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) | [#5065](https://github.com/Koniverse/SubWallet-Extension/pull/5065) | [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) | open, 1 commit | **0** | **none** |
+
+All three now have a dev-side story, written 2026-08-25 (see [W35](../sprint-2026-W35.md)). Only the passkey item has a feature-level **QC** story ([US-42.20](US-42.20-qc-issue-5058-biometric-passkey-login.md)) — the other two do not, so either they get one before this gate runs, or this story carries their feature checks itself.
+
+### Three things from the dev stories that change how this gets tested
+
+**1. #5062 is a P0 that has already stranded a real transfer, and only half its fix is in this repo.** `statemine-LOCAL-USDt` is Kusama-AH-native USDt; `AssetRef.json` offers it an XCM route to Polkadot Asset Hub that the asset **cannot cross**, so the tokens end up locked on the destination chain. Per [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) the fix has two halves — the **data** edits live in `SubWallet-ChainList` (**no issue and no PR found as of 08-25**), and PR #5063 in this repo adds only a **validation guard**. Merging #5063 closes #5062 by the `[Issue-N]` convention while the data half is still undone.
+
+> **This is a release-gate question, not just a QC one.** AC-13 below exists because of it: shipping the guard without the data fix means the bad route is blocked but still present in production data. Confirm which halves are actually in the build before signing this release off.
+
+**2. Passkey is a wrap, not a replacement — and the real risk is browser support.** The master password stays the root of custody ([US-5.16](US-5.16-biometric-passkey-login.md)), so no user can be locked out by design. But it depends on the WebAuthn **PRF extension**, which is supported by fewer browsers than passkeys generally — so the fallback path is an everyday path, not a corner case.
+
+**3. #5064's numbers can be quietly wrong rather than error out.** [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) flags two: `RootClaimableThreshold` is a substrate `I96F32` that must be scaled by `2^32` (unscaled it is wrong by nine orders of magnitude), and a missing-query fallback of `500000` rao. Both produce a **plausible wrong number**, and the PR ships no test — so the claim amount has to be checked against the chain, not just observed to be non-zero.
+
+**Two of the three PRs touch money paths and ship no test at all.** That is not a reason to block, but it is the reason the regression pass below verifies amounts against an explorer rather than against the app's own display.
+
+
+## Stages
+
+1. **Dev merge** — merge all the issues above into the extension, then regression test on the dev environment.
+2. **Master build** — build from master with the release content above, then regression test on an environment closest to production.
+3. **Draft release** — test the draft release build with the release content above, then regression test on a production-like build in draft form.
+4. **Production** — after publishing, a quick recheck on the live production build.
+
+## Things to check
+
+- [ ] AC-1: All 3 release items (passkey login #5058, KAH↔PAH XCM refs #5062, Bittensor manual claim #5064) work correctly after merge into the dev environment
+- [ ] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
+- [ ] AC-3: All 3 release items work correctly on the master build
+- [ ] AC-4: Regression pass on the master build finds no new issues in the app's main functions
+- [ ] AC-5: All 3 release items work correctly on the draft release build
+- [ ] AC-6: Regression pass on the draft release build finds no new issues in the app's main functions
+- [ ] AC-7: Quick recheck on production confirms the release content is live and working, no critical issues
+- [ ] AC-8: The version shown in the extension is 1.3.89 on the draft and production builds
+- [ ] AC-9: The master password still unlocks the wallet on every stage, with the passkey both on and off — nobody can be locked out
+- [ ] AC-10: AC-1 to AC-9 hold on a **fresh install** (no prior version or data)
+- [ ] AC-11: AC-1 to AC-9 hold on an **upgrade** from v1.3.88 (existing accounts, chains, settings and master password carried over, no data loss)
+- [ ] AC-12: The KAH↔PAH USDt route (#5062) is confirmed safe in the build — check **which halves shipped**: the chainlist data fix, the `xcm/utils.ts` guard, or both. If only the guard shipped, the route must be blocked in the UI and the data must be confirmed as still-wrong-but-unreachable, not assumed fixed
+- [ ] AC-13: The Bittensor claim amount (#5064) matches the chain — checked against an explorer or a runtime query, not just against what the app displays
+
+## Regression checklist (main functions)
+
+Run this list at each stage (dev, master, draft, production quick recheck at reduced depth):
+
+- [ ] Create a new account / import an existing account (mnemonic, private key)
+- [ ] Switch between accounts, view balances across chains
+- [ ] Unlock with the master password, and unlock with the passkey if it is on
+- [ ] Auto-lock triggers on time and the wallet reopens correctly
+- [ ] Send a native token, confirm it goes through with correct fee display
+- [ ] Receive a token (show/copy address, QR)
+- [ ] Swap tokens (at least one route)
+- [ ] Stake and unstake on at least one network
+- [ ] Bittensor native staking: manual claim works, and the claimed amount matches the chain — verify against an explorer, since a scaling bug here shows a plausible wrong number rather than an error (covers #5064)
+- [ ] XCM transfer relay chain → parachain
+- [ ] XCM transfer parachain → parachain, with correct fee and balance update on both sides
+- [ ] XCM USDt Kusama Asset Hub ↔ Polkadot Asset Hub — the route is either correctly repointed and a real transfer arrives, or it is blocked outright. **Tokens must not leave the source chain on a route that cannot deliver them** (covers #5062, the P0)
+- [ ] Connect to a dApp (WalletConnect or injected), sign a message and a transaction
+- [ ] Export account (JSON / seed phrase) and remove account
+- [ ] App upgrade path: install v1.3.88, add data, upgrade to v1.3.89, confirm data, settings and the master password are preserved
+
+## Steps
+
+- [ ] TASK-42.21.1 — Confirm the real release content against the release note, update the Background table if it changed
+- [ ] TASK-42.21.1b — For #5062, confirm **which halves of the fix are in the build**: the `SubWallet-ChainList` data edits, the `xcm/utils.ts` guard, or both. Do not sign off the P0 on the guard alone without saying so (AC-13)
+- [ ] TASK-42.21.2 — Merge the passkey login (#5058), the XCM ref repoint (#5062) and the Bittensor manual claim (#5064) into the extension on dev
+- [ ] TASK-42.21.3 — Verify each of the 3 release items on dev (link to US-42.20 for the passkey steps)
+- [ ] TASK-42.21.4 — Run the regression checklist on dev
+- [ ] TASK-42.21.5 — Build from master with the release content, deploy to a near-production environment
+- [ ] TASK-42.21.6 — Verify each of the 3 release items on the master build
+- [ ] TASK-42.21.7 — Run the regression checklist on the master build
+- [ ] TASK-42.21.8 — Test the draft release build (production-like, draft form), confirm the version reads 1.3.89
+- [ ] TASK-42.21.9 — Verify each of the 3 release items on the draft build
+- [ ] TASK-42.21.10 — Run the regression checklist on the draft build
+- [ ] TASK-42.21.12 — Run the draft build as a **fresh install** and repeat the release-item checks
+- [ ] TASK-42.21.13 — Run the draft build as an **upgrade from v1.3.88** and repeat the release-item checks, plus confirm no data loss and that the old master password still works
+- [ ] TASK-42.21.14 — After publish, do a quick recheck of the release content and core functions on production
+- [ ] TASK-42.21.15 — Log any bugs found, tag with the stage they were found on (dev / master / draft / production)
+
+## Bugs found
+
+Not run yet.
+
+## Test notes
+
+Not run yet. The release has not been cut — the shipped version is v1.3.88, and all three content PRs are still open (one has a single review, two have none), so no v1.3.89 build exists to test.
+
+## Retest
+
+No retest carried in. The passkey content was already QC'd at PR level by [US-42.20](US-42.20-qc-issue-5058-biometric-passkey-login.md) (14 / 14, no bugs) — but that ran against an unmerged commit, so this gate re-verifies it on the actual release build rather than inheriting the result.
+
+## Cross-references
+
+- [US-42.20](US-42.20-qc-issue-5058-biometric-passkey-login.md) — passkey login (#5058) feature QC, `done` 2026-08-25, 14 / 14 AC, no bugs
+- [US-42.19](US-42.19-qc-release-extension-v1-3-88.md) — the previous Extension release gate, v1.3.88
+- [US-42.6](US-42.6-qc-release-extension-v1-3-84.md) — the Extension release-gate template this story follows
+- [US-5.16](US-5.16-biometric-passkey-login.md) — dev story for the passkey work (`review`)
+- [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) — dev story for the **P0** KAH↔PAH USDt XCM fix (`review`)
+- [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) — dev story for the Bittensor manual claim (`review`)
+- [Issue #5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062) — Repoint KAH↔PAH XCM refs (**P0**)
+- [Issue #5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) — Support manual claim for Bittensor native staking
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/tests/test-reports/2026-08-25/report-manual.md
+++ b/docs/tests/test-reports/2026-08-25/report-manual.md
@@ -1,0 +1,47 @@
+# Manual Test Report — 2026-08-25
+
+Not tied to one epic — this covers today's test tasks only.
+
+| Field | Value |
+|---|---|
+| Date | 2026-08-25 |
+| Tester | MaiThuongNinni |
+| Environment | PR build |
+| Runner | manual (extension) |
+| Build under test | PR [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061), commit `cab8ebd5ee` |
+| Tasks tested | US-42.20 |
+| Total bugs found | 0 |
+| P0 | 0 |
+| P1 | 0 |
+| P2 | 0 |
+| Status | done |
+
+---
+
+## US-42.20 — Biometric / passkey login ([#5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058))
+
+Checked on fresh install and on an upgrade from v1.3.88. **14 / 14 AC pass.**
+
+### Bugs
+
+None found. All checks passed:
+
+- The passkey option shows in Settings → Security, is off by default, and enrolling it asks for the master password first.
+- The setting survives closing and reopening the extension, and turning it off puts the wallet back to master-password-only.
+- Passkey unlock works from the login screen and from the unlock modal shown before a transaction.
+- Cancelling or failing the passkey prompt returns to the password screen with a clear message — no stuck screen.
+- Auto-lock still triggers on time, and the passkey unlocks the wallet again afterwards.
+- **The master password still unlocks the wallet in every case tested**: with the passkey enrolled, on a browser without WebAuthn PRF support, and after the passkey was removed from the device. No path locks a user out.
+- On a browser without PRF support the passkey option fails cleanly with a readable message and the password path is unaffected.
+- dApp connection and signing work with the passkey unlock in the flow, and the signature is produced over exactly what the confirm screen displayed.
+- Fresh install and upgrade from v1.3.88 both behave the same — accounts, settings and the existing master password all carried over, nothing lost.
+
+### Note on the build
+
+This ran against an **unmerged** commit on an open PR with 0 reviews. If more commits land before #5061 merges, the passkey paths need a re-run against the merged head. The v1.3.89 release gate ([US-42.21](../../../sprints/stories/US-42.21-qc-release-extension-v1-3-89.md)) re-verifies this content on the real release build rather than inheriting this result.
+
+---
+
+## Not covered here
+
+The extension window flickering on open (v1.3.88, macOS 26.4.1) was tested by someone else and is not part of this report.


### PR DESCRIPTION
## What this is

Two QC stories in EPIC-42, plus the manual test report behind them.

| Story | Status | Points |
| --- | --- | --- |
| [US-42.20](docs/sprints/stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) — QC biometric/passkey login (#5058) | **done**, 14 / 14 AC, no bugs | 5 |
| [US-42.21](docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md) — QC release Extension v1.3.89 | `ready`, not run | 8 |

Docs only — no source files touched.

## US-42.20 — passkey login, 14 / 14 pass

Run against PR #5061 at commit `cab8ebd5ee`, on fresh install and on an upgrade from v1.3.88.

The AC are derived from the PR's code, not from the issue — **#5058 is a title with an empty body**, so there is no written spec to test against. That is recorded on the story rather than papered over.

Two results worth a reviewer's attention:

- **The master-password fallback holds** in every case tested — passkey enrolled, browser without WebAuthn PRF support, and passkey removed from the device. No path locks a user out of a wallet. This matters because `wrapWalletPassword()` AES-GCM-encrypts the master password under a PRF-derived key rather than replacing it, so EPIC-5's *non-recoverable by design* decision is not reopened.
- **dApp signing is unchanged** — the signature covers exactly what the confirm screen displayed, so the [US-5.15](docs/sprints/stories/US-5.15-signing-prompt-mode-confusion.md) rule from the #5042 security notice still holds with a new unlock path in front of it.

⚠️ **The result is scoped to that commit.** PR #5061 is still open with **0 reviews**, and two commits landed after the dev story US-5.16 was written (it records 4 commits / 18 files; it is now 6 / 20). If more land before merge, the passkey paths need a re-run against the merged head.

## US-42.21 — release gate, deliberately left unticked

Follows the US-42.19 template across dev → master → draft → production.

**It stays `ready` because v1.3.89 does not exist**: `VERSION` is 1.3.88, there is no v1.3.89 tag, and all three content PRs (#5061, #5063, #5065) are still open. The release content in the story is read from those open PRs and labelled as planned, not from a release note — TASK-1 is to re-check it against the real one.

**AC-12 exists because #5062 is a P0 with a split fix.** The chainlist data edits have no PR at all, and #5063 in this repo adds only a validation guard. Merging that guard closes #5062 by the `[Issue-N]` convention while the bad route stays live in production data — so the gate records *which halves actually shipped* rather than assuming both. Worth confirming before that PR merges.

## Not included

The extension flickering on open (v1.3.88, macOS 26.4.1) is out of scope in both stories — already tested by someone else.

## Checks

- `koni-docs-check-ids` — no new failures; the one pre-existing `US-42.10 version_shipped` error is unchanged from before this branch.
- EPIC-42 and sprint-2026-W35 updated to match (W35 is now 5 stories / 31 points).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
