### PR TITLE
qc: add US-42.22 + US-42.23, close US-42.22 (P0 #5062) 15/15 — both halves of the fix confirmed

### DIFF
--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -54,17 +54,19 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.19](../stories/US-42.19-qc-release-extension-v1-3-88.md) | Release extension v1.3.88 — ParaSpell v2 (#5051) + chainlist (#708, #707, #705); dev, master, draft, production gate | done |
 | [US-42.20](../stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) | Biometric / passkey login (#5058) — PR #5061 build; 14 / 14 AC, no bugs | done |
 | [US-42.21](../stories/US-42.21-qc-release-extension-v1-3-89.md) | Release extension v1.3.89 — passkey login (#5058) + KAH↔PAH XCM refs (#5062) + Bittensor manual claim (#5064); dev, master, draft, production gate | ready |
+| [US-42.22](../stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) | **P0** — Repoint KAH↔PAH USDt XCM refs (#5062); the route that trapped funds | ready |
+| [US-42.23](../stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md) | Manual claim for Bittensor root staking (#5064) | ready |
 
 More rows get added here as testing starts.
 
 ## What this epic actually became — and the two holes it left
 
 > **The stated rule is not the practice.** "Each dev epic gets **one** QA page named
-> `US-42.<epic-number>`" describes a per-epic index. The 20 pages above are numbered
+> `US-42.<epic-number>`" describes a per-epic index. The 22 pages above are numbered
 > **sequentially** and are three different kinds of thing: per-issue QC (42.1–42.5, 42.7, 42.13,
-> 42.14, 42.15, 42.16, 42.17, 42.18, 42.20), per-release gate QC (42.6, 42.9, 42.10, 42.19, 42.21) and per-PR QC (42.11, 42.12). Neither the
+> 42.14, 42.15, 42.16, 42.17, 42.18, 42.20, 42.22, 42.23), per-release gate QC (42.6, 42.9, 42.10, 42.19, 42.21) and per-PR QC (42.11, 42.12). Neither the
 > naming nor the one-page-per-epic promise survived contact. Recorded, not "fixed" — renumbering
-> 20 pages to match a sentence would break every link to them, and the sentence is the cheaper
+> 22 pages to match a sentence would break every link to them, and the sentence is the cheaper
 > thing to change.
 
 **The sequence skips 8** — it runs 42.1…42.7, then 42.9. Nothing was deleted:

--- a/docs/sprints/epics/EPIC-42.md
+++ b/docs/sprints/epics/EPIC-42.md
@@ -54,7 +54,7 @@ An epic can have 20-30 stories. One QA page per story would be too many files. S
 | [US-42.19](../stories/US-42.19-qc-release-extension-v1-3-88.md) | Release extension v1.3.88 — ParaSpell v2 (#5051) + chainlist (#708, #707, #705); dev, master, draft, production gate | done |
 | [US-42.20](../stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) | Biometric / passkey login (#5058) — PR #5061 build; 14 / 14 AC, no bugs | done |
 | [US-42.21](../stories/US-42.21-qc-release-extension-v1-3-89.md) | Release extension v1.3.89 — passkey login (#5058) + KAH↔PAH XCM refs (#5062) + Bittensor manual claim (#5064); dev, master, draft, production gate | ready |
-| [US-42.22](../stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) | **P0** — Repoint KAH↔PAH USDt XCM refs (#5062); the route that trapped funds | ready |
+| [US-42.22](../stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) | **P0** — Repoint KAH↔PAH USDt XCM refs (#5062); 15 / 15 AC, no bugs, both halves of the fix confirmed | done |
 | [US-42.23](../stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md) | Manual claim for Bittensor root staking (#5064) | ready |
 
 More rows get added here as testing starts.

--- a/docs/sprints/sprint-2026-W35.md
+++ b/docs/sprints/sprint-2026-W35.md
@@ -15,7 +15,7 @@ goal: "Two open pull requests, both opened after v1.3.88 shipped. The P0 is #506
 | US-12.23 | Manual claim for Bittensor native staking | EPIC-12 | P2 | 5 | review | ← backlog | [link](stories/US-12.23-bittensor-manual-claim-native-staking.md) |
 | US-42.20 | QC — Biometric / passkey login (#5058) | EPIC-42 | P2 | 5 | done | new | [link](stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) |
 | US-42.21 | QC — Release SubWallet Extension v1.3.89 | EPIC-42 | P2 | 8 | ready | new | [link](stories/US-42.21-qc-release-extension-v1-3-89.md) |
-| US-42.22 | QC — Repoint KAH↔PAH USDt XCM refs (#5062) | EPIC-42 | **P0** | 5 | ready | new | [link](stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) |
+| US-42.22 | QC — Repoint KAH↔PAH USDt XCM refs (#5062) | EPIC-42 | **P0** | 5 | done | new | [link](stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) |
 | US-42.23 | QC — Manual claim for Bittensor native staking (#5064) | EPIC-42 | P2 | 5 | ready | new | [link](stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md) |
 
 **7 stories · 41 points** — 3 dev stories (18 pts) and 4 QC stories (23 pts). The three dev stories
@@ -24,31 +24,32 @@ Between them they carry **two reviews** (`saltict` on #5063, `lw-cdm` on #5065) 
 QC pass** ([US-42.20](stories/US-42.20-qc-issue-5058-biometric-passkey-login.md), 14/14 on #5061 —
 which is the PR with no review at all).
 
-The one `done` in this window is a QC story, not a dev story: US-42.20 passed against a PR build.
-**Nothing has shipped.**
+The two `done` in this window are both QC stories, not dev stories. **No extension code has shipped**
+— every dev PR is still open.
 
-**Every dev story in this window now has its own QC story**, all four written on 2026-08-25
-alongside the dev work rather than after it:
+**Every dev story in this window has its own QC story**, all four written on 2026-08-25 alongside
+the dev work rather than after it:
 
 | Dev story | QC story | State |
 | --- | --- | --- |
 | US-5.16 — passkey login | [US-42.20](stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) | **done**, 14 / 14, no bugs |
-| US-13.19 — **P0** KAH↔PAH USDt | [US-42.22](stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) | `ready` |
+| US-13.19 — **P0** KAH↔PAH USDt | [US-42.22](stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) | **done**, 15 / 15, no bugs |
 | US-12.23 — Bittensor root claim | [US-42.23](stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md) | `ready` |
 | *(all three together)* | [US-42.21](stories/US-42.21-qc-release-extension-v1-3-89.md) — release gate | `ready` |
 
-US-42.20 ran against PR #5061 at commit `cab8ebd5ee`. Because that commit is **not merged**, the
-result is a claim about that build and not about whatever eventually lands; the release gate
-re-verifies rather than inherits it.
+Both passes ran against **unmerged PR builds**, so each is a claim about a specific commit rather
+than about what eventually lands; the release gate re-verifies rather than inherits them. The one
+exception is the **chainlist half of the P0**, which is merged and live in production data
+independently of this repo — see below.
 
 [US-42.21](stories/US-42.21-qc-release-extension-v1-3-89.md) **has not run** — there is no v1.3.89
 tag, `VERSION` is at 1.3.88, and all three content PRs are still open. It stays `ready` until a
 build exists.
 
-The two new feature QC stories are both written from the **code in the PRs**, because neither issue
-carries testable requirements on its own: #5064 has an empty body, and #5062 has a detailed spec
-that describes the **chainlist data fix** — which is not what PR #5063 in this repo does. That gap
-is AC-9 on US-42.22.
+Both new feature QC stories are written from the **code in the PRs**, because neither issue supplies
+testable requirements on its own: #5064 has an empty body, and #5062's spec describes the
+**chainlist data fix**, which is not what PR #5063 in this repo does. Forcing that distinction into
+an acceptance criterion (AC-9 on US-42.22) is what surfaced the correction below.
 
 Small again, and for the same reason [W34](sprint-2026-W34.md) was: this is what has evidence of
 being live. W34 closed at 5 of 5 on that basis.
@@ -63,20 +64,34 @@ Polkadot Asset Hub, and that asset cannot cross the bridge — **the tokens end 
 destination chain**, and this has already happened on a real transfer.
 `statemine-LOCAL-USDC` already models the bridged case correctly, so USDt is the odd one out.
 
-**The fix has two halves and only one of them is in this repository:**
+**The fix has two halves, in two repositories — and both are accounted for:**
 
 | Half | Where | State |
 | --- | --- | --- |
-| Chainlist data — 4 edits to `ChainAsset.json` / `AssetRef.json` / `AssetLogoMap.json` | `SubWallet-ChainList` | **no issue, no PR found** (checked 08-25) |
+| Chainlist data — `ChainAsset.json` +71, `AssetRef.json` +4/−4, `AssetLogoMap.json` +1 | [ChainList PR #709](https://github.com/Koniverse/SubWallet-ChainList/pull/709) `[Issue-5062-extension]` | **merged 2026-08-24** |
 | Validation logic — `xcm/utils.ts` +162 | [PR #5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) | open, approved by `saltict` 08-24 |
 
-The PR's commit is *"feat: update validate logic"*: it adds a **guard**, not the data edits the
-issue prescribes. Merging it will close #5062 by the `[Issue-N]` convention and leave the data half
-undone with its issue closed. **The bad route stays live in production data until half 1 lands** —
-flagged on the story and worth confirming before merge.
+> **Correction, 2026-08-25.** This table previously read *"no issue, no PR found"* for the data half.
+> That was wrong. ChainList PR #709 exists and merged on 08-24 with exactly the four edits the issue
+> prescribes; it was missed because it is titled `[Issue-5062-extension]` and lives in the ChainList
+> repo, so neither an issue search nor a PR search in this repo surfaces it. **The bad route is
+> genuinely removed from production data, not merely blocked in the client** — which is the opposite
+> of the risk recorded here earlier, and worth stating plainly rather than quietly editing.
+>
+> The lesson generalises: a fix that spans repositories is not absent just because it is absent
+> *here*. Search the other repo by issue number in the title, not only by its own issue list.
+
+PR #5063's commit is *"feat: update validate logic"*: it adds a **guard**, not the data edits. With
+the data half merged, the two are belt and braces — the data stops the route being offered, the
+guard stops it being built if it is ever reached again.
 
 **PR #5063 adds no test.** For a bug that has already stranded a real transfer, AC-6 on the story
 asks for a regression test and nothing currently satisfies it.
+
+**QC passed 15 / 15** — [US-42.22](stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md),
+2026-08-25, fresh install and upgrade, no bugs. It confirmed both halves are in the build, that the
+KAH-native USDt offers no XCM route at all, and that nothing else was caught by the guard: USDC on
+the same route, same-consensus XCM, and other supported cross-consensus routes all still work.
 
 ### US-5.16 — the empty issue got answered by code
 

--- a/docs/sprints/sprint-2026-W35.md
+++ b/docs/sprints/sprint-2026-W35.md
@@ -15,8 +15,10 @@ goal: "Two open pull requests, both opened after v1.3.88 shipped. The P0 is #506
 | US-12.23 | Manual claim for Bittensor native staking | EPIC-12 | P2 | 5 | review | ← backlog | [link](stories/US-12.23-bittensor-manual-claim-native-staking.md) |
 | US-42.20 | QC — Biometric / passkey login (#5058) | EPIC-42 | P2 | 5 | done | new | [link](stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) |
 | US-42.21 | QC — Release SubWallet Extension v1.3.89 | EPIC-42 | P2 | 8 | ready | new | [link](stories/US-42.21-qc-release-extension-v1-3-89.md) |
+| US-42.22 | QC — Repoint KAH↔PAH USDt XCM refs (#5062) | EPIC-42 | **P0** | 5 | ready | new | [link](stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) |
+| US-42.23 | QC — Manual claim for Bittensor native staking (#5064) | EPIC-42 | P2 | 5 | ready | new | [link](stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md) |
 
-**5 stories · 31 points** — 3 dev stories (18 pts) and 2 QC stories (13 pts). The three dev stories
+**7 stories · 41 points** — 3 dev stories (18 pts) and 4 QC stories (23 pts). The three dev stories
 are all open PRs with no merge yet, so **none of them is `done` and none has a `version_shipped`.**
 Between them they carry **two reviews** (`saltict` on #5063, `lw-cdm` on #5065) and **one completed
 QC pass** ([US-42.20](stories/US-42.20-qc-issue-5058-biometric-passkey-login.md), 14/14 on #5061 —
@@ -25,19 +27,28 @@ which is the PR with no review at all).
 The one `done` in this window is a QC story, not a dev story: US-42.20 passed against a PR build.
 **Nothing has shipped.**
 
-The two QC stories were added on 2026-08-25 alongside the dev stories, not after them:
-[US-42.20](stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) covers the passkey feature —
-**`done` 2026-08-25, 14 / 14 AC, no bugs**, run against PR #5061 at commit `cab8ebd5ee`. Because
-that commit is **not merged**, the result is a claim about that build and not about whatever
-eventually lands; the release gate re-verifies rather than inherits it.
+**Every dev story in this window now has its own QC story**, all four written on 2026-08-25
+alongside the dev work rather than after it:
 
-[US-42.21](stories/US-42.21-qc-release-extension-v1-3-89.md) is the v1.3.89 release gate and **has
-not run** — there is no v1.3.89 tag, `VERSION` is at 1.3.88, and all three content PRs are still
-open. It stays `ready` until a build exists.
+| Dev story | QC story | State |
+| --- | --- | --- |
+| US-5.16 — passkey login | [US-42.20](stories/US-42.20-qc-issue-5058-biometric-passkey-login.md) | **done**, 14 / 14, no bugs |
+| US-13.19 — **P0** KAH↔PAH USDt | [US-42.22](stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) | `ready` |
+| US-12.23 — Bittensor root claim | [US-42.23](stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md) | `ready` |
+| *(all three together)* | [US-42.21](stories/US-42.21-qc-release-extension-v1-3-89.md) — release gate | `ready` |
 
-One gap that follows from the table: the **P0** (US-13.19) and the Bittensor claim (US-12.23) have
-**no feature-level QC story**, only the release gate. The passkey item is the only one of the three
-with its own QC pass.
+US-42.20 ran against PR #5061 at commit `cab8ebd5ee`. Because that commit is **not merged**, the
+result is a claim about that build and not about whatever eventually lands; the release gate
+re-verifies rather than inherits it.
+
+[US-42.21](stories/US-42.21-qc-release-extension-v1-3-89.md) **has not run** — there is no v1.3.89
+tag, `VERSION` is at 1.3.88, and all three content PRs are still open. It stays `ready` until a
+build exists.
+
+The two new feature QC stories are both written from the **code in the PRs**, because neither issue
+carries testable requirements on its own: #5064 has an empty body, and #5062 has a detailed spec
+that describes the **chainlist data fix** — which is not what PR #5063 in this repo does. That gap
+is AC-9 on US-42.22.
 
 Small again, and for the same reason [W34](sprint-2026-W34.md) was: this is what has evidence of
 being live. W34 closed at 5 of 5 on that basis.

--- a/docs/sprints/stories/US-42.20-qc-issue-5058-biometric-passkey-login.md
+++ b/docs/sprints/stories/US-42.20-qc-issue-5058-biometric-passkey-login.md
@@ -26,7 +26,7 @@ The issue itself is a **title with an empty body** — no description, no accept
 
 | | |
 | --- | --- |
-| Issue | [#5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058) — OPEN, opened 2026-08-13 by `tunghp2002` |
+| Issue | [#5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058) — opened 2026-08-13 by `tunghp2002`, **closed by hand 2026-08-25** with no commit attached, while PR #5061 is still open |
 | PR | [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061) — OPEN, `koni/dev/issue-5058` → `subwallet-dev` |
 | Size | 6 commits, +1317 / −54, 20 files (checked 2026-08-25) |
 | Last commit | `cab8ebd5ee` *"Chore: update UI"*, 2026-08-25 |
@@ -129,6 +129,8 @@ The two checks worth recording separately, because they are the ones that could 
 N/A — all AC passed on the first run.
 
 **One caveat on the build.** This ran against `cab8ebd5ee` while PR #5061 was still open with **0 reviews**. If more commits land before it merges, the passkey paths need a re-run against the merged head — this result is a claim about the commit above, not about whatever merges later.
+
+**The issue being closed does not mean the feature shipped.** #5058 was closed by hand on 2026-08-25 with no commit attached, and PR #5061 is still open and unmerged — so `dev` does not contain this code. This QC pass and the closed issue are both true; neither makes the feature released. `version_shipped` stays empty until it merges and ships.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md
+++ b/docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md
@@ -34,9 +34,18 @@ All three now have both a dev-side story and a feature-level **QC** story, all w
 
 ### Three things from the dev stories that change how this gets tested
 
-**1. #5062 is a P0 that has already stranded a real transfer, and only half its fix is in this repo.** `statemine-LOCAL-USDt` is Kusama-AH-native USDt; `AssetRef.json` offers it an XCM route to Polkadot Asset Hub that the asset **cannot cross**, so the tokens end up locked on the destination chain. Per [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) the fix has two halves — the **data** edits live in `SubWallet-ChainList` (**no issue and no PR found as of 08-25**), and PR #5063 in this repo adds only a **validation guard**. Merging #5063 closes #5062 by the `[Issue-N]` convention while the data half is still undone.
+**1. #5062 is a P0 that has already stranded a real transfer, and its fix spans two repositories.** `statemine-LOCAL-USDt` is Kusama-AH-native USDt; `AssetRef.json` offered it an XCM route to Polkadot Asset Hub that the asset **cannot cross**, so the tokens ended up locked on the destination chain.
 
-> **This is a release-gate question, not just a QC one.** AC-12 below exists because of it: shipping the guard without the data fix means the bad route is blocked but still present in production data. Confirm which halves are actually in the build before signing this release off.
+**Both halves are now accounted for**, and [US-42.22](US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) passed 15 / 15 against them:
+
+| Half | Where | State |
+| --- | --- | --- |
+| **Data** — bridged asset, missing multilocation, both `AssetRef` directions repointed, logo | [ChainList PR #709](https://github.com/Koniverse/SubWallet-ChainList/pull/709) | **merged 2026-08-24** |
+| **Guard** — `isXcmCurrencySupported()` | [PR #5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) | open, approved |
+
+> *Correction:* this story and [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) previously recorded the data half as *"no issue and no PR found"*. That was wrong — ChainList PR #709 exists and merged on 08-24; it was missed because it is titled `[Issue-5062-extension]` and lives in the ChainList repo. The route is genuinely removed, not merely blocked.
+
+> **AC-12 still matters at the gate.** The chainlist data is already live in production, but PR #5063 is not merged. Confirm on the actual release build that **both** halves are present — the guard failing open on a network error means the data half is what actually removes the route.
 
 **2. Passkey is a wrap, not a replacement — and the real risk is browser support.** The master password stays the root of custody ([US-5.16](US-5.16-biometric-passkey-login.md)), so no user can be locked out by design. But it depends on the WebAuthn **PRF extension**, which is supported by fewer browsers than passkeys generally — so the fallback path is an everyday path, not a corner case.
 

--- a/docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md
+++ b/docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md
@@ -26,23 +26,25 @@ Planned release content for v1.3.89:
 
 | Item | Issue | PR | Dev story | State on 2026-08-25 | Reviews | Tests in PR |
 | --- | --- | --- | --- | --- | --- | --- |
-| **P0** — Repoint KAH↔PAH USDt XCM refs | [#5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062) | [#5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) | [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) | open, `review` | 1 (`saltict`) | **none** |
-| Biometric / passkey login | [#5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058) | [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061) | [US-5.16](US-5.16-biometric-passkey-login.md) | open, 6 commits | **0** | 2 spec files |
-| Manual claim for Bittensor native staking | [#5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) | [#5065](https://github.com/Koniverse/SubWallet-Extension/pull/5065) | [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) | open, 1 commit | **0** | **none** |
+| **P0** — Repoint KAH↔PAH USDt XCM refs | [#5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062) | [#5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) | [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) · QC [US-42.22](US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) | open, approved | 1 (`saltict`) | **none** |
+| Biometric / passkey login | [#5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058) | [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061) | [US-5.16](US-5.16-biometric-passkey-login.md) · QC [US-42.20](US-42.20-qc-issue-5058-biometric-passkey-login.md) | open, 6 commits | **0** | 2 spec files |
+| Manual claim for Bittensor native staking | [#5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) | [#5065](https://github.com/Koniverse/SubWallet-Extension/pull/5065) | [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) · QC [US-42.23](US-42.23-qc-issue-5064-bittensor-manual-claim.md) | open, approved | 1 (`lw-cdm`) | **none** |
 
-All three now have a dev-side story, written 2026-08-25 (see [W35](../sprint-2026-W35.md)). Only the passkey item has a feature-level **QC** story ([US-42.20](US-42.20-qc-issue-5058-biometric-passkey-login.md)) — the other two do not, so either they get one before this gate runs, or this story carries their feature checks itself.
+All three now have both a dev-side story and a feature-level **QC** story, all written 2026-08-25 (see [W35](../sprint-2026-W35.md)): [US-42.20](US-42.20-qc-issue-5058-biometric-passkey-login.md) for the passkey (**done**, 14 / 14, no bugs), [US-42.22](US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) for the P0 XCM fix, and [US-42.23](US-42.23-qc-issue-5064-bittensor-manual-claim.md) for the Bittensor claim. **This gate re-verifies their content on the real release build rather than inheriting those results** — all three ran against unmerged PR builds.
 
 ### Three things from the dev stories that change how this gets tested
 
 **1. #5062 is a P0 that has already stranded a real transfer, and only half its fix is in this repo.** `statemine-LOCAL-USDt` is Kusama-AH-native USDt; `AssetRef.json` offers it an XCM route to Polkadot Asset Hub that the asset **cannot cross**, so the tokens end up locked on the destination chain. Per [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) the fix has two halves — the **data** edits live in `SubWallet-ChainList` (**no issue and no PR found as of 08-25**), and PR #5063 in this repo adds only a **validation guard**. Merging #5063 closes #5062 by the `[Issue-N]` convention while the data half is still undone.
 
-> **This is a release-gate question, not just a QC one.** AC-13 below exists because of it: shipping the guard without the data fix means the bad route is blocked but still present in production data. Confirm which halves are actually in the build before signing this release off.
+> **This is a release-gate question, not just a QC one.** AC-12 below exists because of it: shipping the guard without the data fix means the bad route is blocked but still present in production data. Confirm which halves are actually in the build before signing this release off.
 
 **2. Passkey is a wrap, not a replacement — and the real risk is browser support.** The master password stays the root of custody ([US-5.16](US-5.16-biometric-passkey-login.md)), so no user can be locked out by design. But it depends on the WebAuthn **PRF extension**, which is supported by fewer browsers than passkeys generally — so the fallback path is an everyday path, not a corner case.
 
-**3. #5064's numbers can be quietly wrong rather than error out.** [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) flags two: `RootClaimableThreshold` is a substrate `I96F32` that must be scaled by `2^32` (unscaled it is wrong by nine orders of magnitude), and a missing-query fallback of `500000` rao. Both produce a **plausible wrong number**, and the PR ships no test — so the claim amount has to be checked against the chain, not just observed to be non-zero.
+**3. #5064's numbers can be quietly wrong rather than error out.** [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) flagged two risks: `RootClaimableThreshold` is a substrate `I96F32` that must be scaled by `2^32` (unscaled it is wrong by nine orders of magnitude), and a missing-query fallback of `500000` rao.
 
-**Two of the three PRs touch money paths and ship no test at all.** That is not a reason to block, but it is the reason the regression pass below verifies amounts against an explorer rather than against the app's own display.
+*Reading the diff answers both:* the code divides the raw bits by `2^32` and falls back to `500000` rao only when the query is absent, NaN or ≤ 0. **The scaling is handled.** What remains untested is whether the number the *user* sees matches the chain — a wrong amount here still shows a plausible figure rather than an error, and the PR ships no test. So the claim amount is verified against an explorer, not against the app's own display. Detail in [US-42.23](US-42.23-qc-issue-5064-bittensor-manual-claim.md).
+
+**Two of the three PRs touch money paths and ship no test at all** — #5063 (the P0) and #5065. Both are approved; the passkey PR ships 2 spec files but has no review. That is not a reason to block, but it is the reason the regression pass below verifies amounts against an explorer rather than against the app's own display.
 
 
 ## Stages

--- a/docs/sprints/stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md
+++ b/docs/sprints/stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md
@@ -1,0 +1,133 @@
+---
+id: US-42.22
+title: "QC — Repoint KAH↔PAH USDt XCM refs (#5062)"
+epic: EPIC-42
+status: ready
+priority: P0
+points: 5
+sprint: sprint-2026-W35
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-08-25
+updated: 2026-08-25
+---
+
+## Goal
+
+Check that USDt can no longer be sent on a Kusama Asset Hub ↔ Polkadot Asset Hub route that cannot deliver it — the route that has already trapped a real transfer — and that every route which *does* work still works.
+
+## Background
+
+This story covers [issue #5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062) — *"Repoint KAH<>PAH XCM refs"*. **This is a P0: money has already been lost to it.**
+
+### What goes wrong
+
+Kusama Asset Hub has **two** USDt. Only one of them can cross the Polkadot↔Kusama bridge:
+
+| Token | What it is | Can it cross? |
+| --- | --- | --- |
+| `statemine-LOCAL-USDt` | Kusama-AH-native USDt (`assets` pallet #1984) | **No** |
+| `statemine-LOCAL-USDt-Polkadot` | the bridged flavour (new, `isBridged: true`) | Yes |
+
+The wallet only registered the first one, and `AssetRef.json` offered it an XCM route to Polkadot Asset Hub. The origin chain accepts the transfer, and **the funds are then trapped on the destination**. `statemine-LOCAL-USDC` already modelled this correctly — USDt was the odd one out.
+
+### The fix has two halves, in two repositories
+
+| Half | Where | State on 2026-08-25 |
+| --- | --- | --- |
+| **Data** — add the bridged asset, add the missing multilocation, repoint both `AssetRef` directions, add the logo | `SubWallet-ChainList` | **no issue and no PR found** |
+| **Guard** — refuse the transfer before building it | [PR #5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063), +197 / −14, 12 files, approved by `saltict` | open |
+
+> **This matters for how the story is read.** PR #5063 does *not* repoint anything — it adds a check that blocks the bad route. If the guard ships without the data fix, the bad route is unreachable but the wrong data is still live. AC-9 is where that gets recorded rather than assumed.
+
+### How the guard works — read from the branch
+
+`isXcmCurrencySupported()` in `xcm/utils.ts` only acts when origin and destination are in **different consensus systems** (Polkadot vs Kusama); same-consensus routes return `true` immediately and are untouched. For a cross-consensus route it calls ParaSpell `/v2/supported-assets?origin=…&destination=…` and compares the token's `paraSpellIdentifyV4.location` against the supported list, normalising the spelling differences between the two sources (`Here` vs `{Here: null}`, `1,984` vs `1984`, `X1` object vs array).
+
+Three behaviours that are the actual test targets:
+
+1. **It fails open.** If the API call throws, the function returns `true` and the transfer proceeds — the comment says *"the dry-run is still ahead"*. So a network failure must not block good transfers.
+2. **It caches for 30 minutes** per origin-destination pair, and a failed request is evicted from the cache.
+3. **It is checked in two places** — `Extension.ts` blocks the transfer up front with a readable error, and `buildXcm()` throws as a backstop because *"the swap and earning flows reach buildXcm without that check"*. Both paths need testing, not just the Send screen.
+
+The user-facing message (new, 5 languages):
+
+> *"{symbol} on {originChain} can't be transferred to {destinationChain} network. Please use another token or change the destination network"*
+
+**PR #5063 ships no test.** For a bug that has already stranded a real transfer, that is worth noting in the QC record.
+
+## Things to check
+
+**The bug itself — the route that trapped funds**
+
+- [ ] AC-1: On the Send screen, sending `statemine-LOCAL-USDt` (the KAH-native USDt) from Kusama Asset Hub to Polkadot Asset Hub is **blocked**, with the message above shown clearly — the transaction is never submitted
+- [ ] AC-2: The bridged USDt (`USDt-Polkadot`) **can** be sent Kusama Asset Hub → Polkadot Asset Hub, arrives on the destination, and the balance updates on both sides
+- [ ] AC-3: The reverse direction, Polkadot Asset Hub → Kusama Asset Hub, delivers to the bridged asset and the funds arrive
+
+**Nothing else got blocked by mistake**
+
+- [ ] AC-4: USDC on the same KAH↔PAH route still works — it was already modelled correctly and must be unaffected
+- [ ] AC-5: Same-consensus XCM is untouched: relay → parachain, parachain → relay, and parachain → parachain inside Polkadot all still work with correct fees
+- [ ] AC-6: Other cross-consensus routes that are genuinely supported still work — the guard blocks one token, not the bridge
+
+**The two entry points**
+
+- [ ] AC-7: The **Send / transfer** screen blocks the bad route up front (the `Extension.ts` check)
+- [ ] AC-8: The **swap** and **earning/XCM-deposit** flows also refuse it — these reach `buildXcm()` without the up-front check, and must not slip through with a raw or unreadable error
+
+**Which halves actually shipped**
+
+- [ ] AC-9: Record whether the build contains the **chainlist data fix**, the **guard**, or both. If only the guard shipped, confirm the bad route is unreachable in the UI **and** state plainly that the wrong data is still live — do not report #5062 as fully fixed
+- [ ] AC-10: If the data fix did ship: the bridged asset shows the right symbol (`USDt-Polkadot`), 6 decimals, its logo, and a price; and the KAH-native USDt offers **no** XCM route at all
+
+**Failure modes of the guard itself**
+
+- [ ] AC-11: With the network unavailable (ParaSpell unreachable), good XCM transfers still work — the guard fails open and does not block valid routes
+- [ ] AC-12: The block is consistent across repeated attempts within the same session (the 30-minute cache does not let a blocked route through on a retry)
+- [ ] AC-13: The error message is translated and readable in all 5 languages (en, ja, ru, vi, zh) — no raw key, no untranslated string
+
+**Install paths**
+
+- [ ] AC-14: AC-1 to AC-13 hold on a **fresh install**
+- [ ] AC-15: AC-1 to AC-13 hold on an **upgrade from v1.3.88** — in particular, a user who already had the KAH-native USDt visible does not keep a usable bad route after the upgrade
+
+## Steps
+
+- [ ] TASK-42.22.1 — Confirm the build under test, note the commit, and record which halves of the fix it contains (AC-9)
+- [ ] TASK-42.22.2 — Try sending KAH-native USDt to Polkadot Asset Hub, confirm it is blocked with the correct message (AC-1)
+- [ ] TASK-42.22.3 — Send the bridged USDt on the same route with a real amount, confirm it arrives (AC-2)
+- [ ] TASK-42.22.4 — Send the reverse direction PAH → KAH, confirm it arrives (AC-3)
+- [ ] TASK-42.22.5 — Send USDC on the KAH↔PAH route, confirm it is unaffected (AC-4)
+- [ ] TASK-42.22.6 — Run same-consensus XCM: relay → para, para → relay, para → para (AC-5)
+- [ ] TASK-42.22.7 — Try the bad token from the swap flow and from an earning/XCM deposit, confirm both refuse it readably (AC-8)
+- [ ] TASK-42.22.8 — Check the bridged asset's symbol, decimals, logo and price, and that the native one has no XCM route (AC-10)
+- [ ] TASK-42.22.9 — Block network access to the ParaSpell endpoint, confirm valid XCM still works (AC-11)
+- [ ] TASK-42.22.10 — Retry a blocked route several times in one session, confirm it stays blocked (AC-12)
+- [ ] TASK-42.22.11 — Switch the app through all 5 languages and read the error message (AC-13)
+- [ ] TASK-42.22.12 — Repeat the main checks on a **fresh install** (AC-14)
+- [ ] TASK-42.22.13 — Repeat them on an **upgrade from v1.3.88**, with the KAH-native USDt already present before upgrading (AC-15)
+- [ ] TASK-42.22.14 — Log any bugs found in the manual test report
+
+## Bugs found
+
+Not run yet.
+
+## Test notes
+
+Not run yet. PR #5063 is open and approved by `saltict`; the chainlist data half had no PR as of 2026-08-25, so **check both halves before starting** — the result means different things depending on what is in the build.
+
+## Retest
+
+N/A — not run yet.
+
+## Cross-references
+
+- [Issue #5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062) — Repoint KAH↔PAH XCM refs (**P0**)
+- [PR #5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) — the guard half of the fix
+- [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) — the dev-side story for this issue
+- [US-42.21](US-42.21-qc-release-extension-v1-3-89.md) — the v1.3.89 release gate this feeds into
+- [US-42.17](US-42.17-qc-issue-5051-paraspell-api-v2.md) — ParaSpell v2 QC; the same XCM code path
+- [US-42.18](US-42.18-qc-issue-705-remove-dropped-xcm-routes.md) — earlier removal of dropped XCM routes
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/sprints/stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md
+++ b/docs/sprints/stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md
@@ -2,7 +2,7 @@
 id: US-42.22
 title: "QC — Repoint KAH↔PAH USDt XCM refs (#5062)"
 epic: EPIC-42
-status: ready
+status: done
 priority: P0
 points: 5
 sprint: sprint-2026-W35
@@ -37,10 +37,12 @@ The wallet only registered the first one, and `AssetRef.json` offered it an XCM 
 
 | Half | Where | State on 2026-08-25 |
 | --- | --- | --- |
-| **Data** — add the bridged asset, add the missing multilocation, repoint both `AssetRef` directions, add the logo | `SubWallet-ChainList` | **no issue and no PR found** |
+| **Data** — add the bridged asset, add the missing multilocation, repoint both `AssetRef` directions, add the logo | [ChainList PR #709](https://github.com/Koniverse/SubWallet-ChainList/pull/709) — `[Issue-5062-extension] Repoint KAH<>PAH XCM refs`, +151 / −8 | **MERGED 2026-08-24** |
 | **Guard** — refuse the transfer before building it | [PR #5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063), +197 / −14, 12 files, approved by `saltict` | open |
 
-> **This matters for how the story is read.** PR #5063 does *not* repoint anything — it adds a check that blocks the bad route. If the guard ships without the data fix, the bad route is unreachable but the wrong data is still live. AC-9 is where that gets recorded rather than assumed.
+> **Both halves are accounted for — this was checked, not assumed.** Earlier drafts of this story and of [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) recorded the data half as *"no issue, no PR found"*. That was wrong: the PR exists in the ChainList repo, merged **2026-08-24**, and it carries exactly the four edits the issue prescribed — `ChainAsset.json` +71 (the new bridged asset and the missing multilocation), `AssetRef.json` +4 / −4 (both directions repointed), and `AssetLogoMap.json` +1. It was missed because it is titled `[Issue-5062-extension]` and lives in a different repository. AC-9 records this.
+>
+> PR #5063 does *not* repoint anything — it adds a check that blocks the bad route. It is the **belt** to the data fix's **braces**: the data stops the route being offered, the guard stops it being built if it ever is again.
 
 ### How the guard works — read from the branch
 
@@ -62,65 +64,87 @@ The user-facing message (new, 5 languages):
 
 **The bug itself — the route that trapped funds**
 
-- [ ] AC-1: On the Send screen, sending `statemine-LOCAL-USDt` (the KAH-native USDt) from Kusama Asset Hub to Polkadot Asset Hub is **blocked**, with the message above shown clearly — the transaction is never submitted
-- [ ] AC-2: The bridged USDt (`USDt-Polkadot`) **can** be sent Kusama Asset Hub → Polkadot Asset Hub, arrives on the destination, and the balance updates on both sides
-- [ ] AC-3: The reverse direction, Polkadot Asset Hub → Kusama Asset Hub, delivers to the bridged asset and the funds arrive
+- [x] AC-1: On the Send screen, sending `statemine-LOCAL-USDt` (the KAH-native USDt) from Kusama Asset Hub to Polkadot Asset Hub is **blocked**, with the message above shown clearly — the transaction is never submitted
+- [x] AC-2: The bridged USDt (`USDt-Polkadot`) **can** be sent Kusama Asset Hub → Polkadot Asset Hub, arrives on the destination, and the balance updates on both sides
+- [x] AC-3: The reverse direction, Polkadot Asset Hub → Kusama Asset Hub, delivers to the bridged asset and the funds arrive
 
 **Nothing else got blocked by mistake**
 
-- [ ] AC-4: USDC on the same KAH↔PAH route still works — it was already modelled correctly and must be unaffected
-- [ ] AC-5: Same-consensus XCM is untouched: relay → parachain, parachain → relay, and parachain → parachain inside Polkadot all still work with correct fees
-- [ ] AC-6: Other cross-consensus routes that are genuinely supported still work — the guard blocks one token, not the bridge
+- [x] AC-4: USDC on the same KAH↔PAH route still works — it was already modelled correctly and must be unaffected
+- [x] AC-5: Same-consensus XCM is untouched: relay → parachain, parachain → relay, and parachain → parachain inside Polkadot all still work with correct fees
+- [x] AC-6: Other cross-consensus routes that are genuinely supported still work — the guard blocks one token, not the bridge
 
 **The two entry points**
 
-- [ ] AC-7: The **Send / transfer** screen blocks the bad route up front (the `Extension.ts` check)
-- [ ] AC-8: The **swap** and **earning/XCM-deposit** flows also refuse it — these reach `buildXcm()` without the up-front check, and must not slip through with a raw or unreadable error
+- [x] AC-7: The **Send / transfer** screen blocks the bad route up front (the `Extension.ts` check)
+- [x] AC-8: The **swap** and **earning/XCM-deposit** flows also refuse it — these reach `buildXcm()` without the up-front check, and must not slip through with a raw or unreadable error
 
 **Which halves actually shipped**
 
-- [ ] AC-9: Record whether the build contains the **chainlist data fix**, the **guard**, or both. If only the guard shipped, confirm the bad route is unreachable in the UI **and** state plainly that the wrong data is still live — do not report #5062 as fully fixed
-- [ ] AC-10: If the data fix did ship: the bridged asset shows the right symbol (`USDt-Polkadot`), 6 decimals, its logo, and a price; and the KAH-native USDt offers **no** XCM route at all
+- [x] AC-9: Record whether the build contains the **chainlist data fix**, the **guard**, or both. If only the guard shipped, confirm the bad route is unreachable in the UI **and** state plainly that the wrong data is still live — do not report #5062 as fully fixed
+- [x] AC-10: If the data fix did ship: the bridged asset shows the right symbol (`USDt-Polkadot`), 6 decimals, its logo, and a price; and the KAH-native USDt offers **no** XCM route at all
 
 **Failure modes of the guard itself**
 
-- [ ] AC-11: With the network unavailable (ParaSpell unreachable), good XCM transfers still work — the guard fails open and does not block valid routes
-- [ ] AC-12: The block is consistent across repeated attempts within the same session (the 30-minute cache does not let a blocked route through on a retry)
-- [ ] AC-13: The error message is translated and readable in all 5 languages (en, ja, ru, vi, zh) — no raw key, no untranslated string
+- [x] AC-11: With the network unavailable (ParaSpell unreachable), good XCM transfers still work — the guard fails open and does not block valid routes
+- [x] AC-12: The block is consistent across repeated attempts within the same session (the 30-minute cache does not let a blocked route through on a retry)
+- [x] AC-13: The error message is translated and readable in all 5 languages (en, ja, ru, vi, zh) — no raw key, no untranslated string
 
 **Install paths**
 
-- [ ] AC-14: AC-1 to AC-13 hold on a **fresh install**
-- [ ] AC-15: AC-1 to AC-13 hold on an **upgrade from v1.3.88** — in particular, a user who already had the KAH-native USDt visible does not keep a usable bad route after the upgrade
+- [x] AC-14: AC-1 to AC-13 hold on a **fresh install**
+- [x] AC-15: AC-1 to AC-13 hold on an **upgrade from v1.3.88** — in particular, a user who already had the KAH-native USDt visible does not keep a usable bad route after the upgrade
 
 ## Steps
 
-- [ ] TASK-42.22.1 — Confirm the build under test, note the commit, and record which halves of the fix it contains (AC-9)
-- [ ] TASK-42.22.2 — Try sending KAH-native USDt to Polkadot Asset Hub, confirm it is blocked with the correct message (AC-1)
-- [ ] TASK-42.22.3 — Send the bridged USDt on the same route with a real amount, confirm it arrives (AC-2)
-- [ ] TASK-42.22.4 — Send the reverse direction PAH → KAH, confirm it arrives (AC-3)
-- [ ] TASK-42.22.5 — Send USDC on the KAH↔PAH route, confirm it is unaffected (AC-4)
-- [ ] TASK-42.22.6 — Run same-consensus XCM: relay → para, para → relay, para → para (AC-5)
-- [ ] TASK-42.22.7 — Try the bad token from the swap flow and from an earning/XCM deposit, confirm both refuse it readably (AC-8)
-- [ ] TASK-42.22.8 — Check the bridged asset's symbol, decimals, logo and price, and that the native one has no XCM route (AC-10)
-- [ ] TASK-42.22.9 — Block network access to the ParaSpell endpoint, confirm valid XCM still works (AC-11)
-- [ ] TASK-42.22.10 — Retry a blocked route several times in one session, confirm it stays blocked (AC-12)
-- [ ] TASK-42.22.11 — Switch the app through all 5 languages and read the error message (AC-13)
-- [ ] TASK-42.22.12 — Repeat the main checks on a **fresh install** (AC-14)
-- [ ] TASK-42.22.13 — Repeat them on an **upgrade from v1.3.88**, with the KAH-native USDt already present before upgrading (AC-15)
-- [ ] TASK-42.22.14 — Log any bugs found in the manual test report
+- [x] TASK-42.22.1 — Confirm the build under test, note the commit, and record which halves of the fix it contains (AC-9)
+- [x] TASK-42.22.2 — Try sending KAH-native USDt to Polkadot Asset Hub, confirm it is blocked with the correct message (AC-1)
+- [x] TASK-42.22.3 — Send the bridged USDt on the same route with a real amount, confirm it arrives (AC-2)
+- [x] TASK-42.22.4 — Send the reverse direction PAH → KAH, confirm it arrives (AC-3)
+- [x] TASK-42.22.5 — Send USDC on the KAH↔PAH route, confirm it is unaffected (AC-4)
+- [x] TASK-42.22.6 — Run same-consensus XCM: relay → para, para → relay, para → para (AC-5)
+- [x] TASK-42.22.7 — Try the bad token from the swap flow and from an earning/XCM deposit, confirm both refuse it readably (AC-8)
+- [x] TASK-42.22.8 — Check the bridged asset's symbol, decimals, logo and price, and that the native one has no XCM route (AC-10)
+- [x] TASK-42.22.9 — Block network access to the ParaSpell endpoint, confirm valid XCM still works (AC-11)
+- [x] TASK-42.22.10 — Retry a blocked route several times in one session, confirm it stays blocked (AC-12)
+- [x] TASK-42.22.11 — Switch the app through all 5 languages and read the error message (AC-13)
+- [x] TASK-42.22.12 — Repeat the main checks on a **fresh install** (AC-14)
+- [x] TASK-42.22.13 — Repeat them on an **upgrade from v1.3.88**, with the KAH-native USDt already present before upgrading (AC-15)
+- [x] TASK-42.22.14 — Log any bugs found in the manual test report
 
 ## Bugs found
 
-Not run yet.
+None.
 
 ## Test notes
 
-Not run yet. PR #5063 is open and approved by `saltict`; the chainlist data half had no PR as of 2026-08-25, so **check both halves before starting** — the result means different things depending on what is in the build.
+- **Tested on**: 2026-08-25 — Extension, fresh install + upgrade from v1.3.88
+- **Environment**: PR [#5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) build, with the merged chainlist data
+- **Passed**: 15 / 15 AC
+- **Full report**: [report-manual.md](../../tests/test-reports/2026-08-25/report-manual.md)
+
+**Both halves of the fix are in the build** (AC-9) — this is the answer the story was written to force, and it is the good one:
+
+| Half | Where | State |
+| --- | --- | --- |
+| Data — bridged asset, missing multilocation, both `AssetRef` directions repointed, logo | [ChainList PR #709](https://github.com/Koniverse/SubWallet-ChainList/pull/709) | **merged 2026-08-24** |
+| Guard — `isXcmCurrencySupported()` | [PR #5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) | open, approved |
+
+So #5062 is genuinely fixed, not merely blocked. The KAH-native USDt no longer offers an XCM route at all, and the bridged `USDt-Polkadot` carries the right symbol, 6 decimals, logo and price.
+
+The three checks worth recording separately:
+
+- **The route that trapped funds is gone** (AC-1, AC-10). It is not offered by the data, and the guard refuses it if it is ever reached.
+- **Nothing else was caught by the guard** (AC-4, AC-5, AC-6). USDC on the same KAH↔PAH route still works, same-consensus XCM is untouched, and other genuinely-supported cross-consensus routes still go through — the guard blocks one token, not the bridge.
+- **Both entry points refuse it** (AC-7, AC-8). The Send screen blocks up front, and the swap and earning/XCM-deposit flows — which reach `buildXcm()` without the up-front check — also refuse it with a readable message rather than a raw error.
+
+**The guard fails open as designed** (AC-11): with ParaSpell unreachable, valid XCM transfers still work. That is the intended trade-off — the dry-run is still ahead — but it does mean the guard is not a defence during an outage. The data fix is what actually removes the route, which is why AC-9 mattered.
 
 ## Retest
 
-N/A — not run yet.
+N/A — all AC passed on the first run.
+
+**One caveat on the build.** PR #5063 is still open and unmerged, so this result is a claim about that build. The chainlist half **is** merged and live, so the data side of the fix is in production regardless of when #5063 lands.
 
 ## Cross-references
 

--- a/docs/sprints/stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md
+++ b/docs/sprints/stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md
@@ -9,7 +9,7 @@ sprint: sprint-2026-W35
 version_shipped:
 prd_ref: []
 assignee: MaiThuongNinni
-commit:
+commit: 2e122cfb0d
 created: 2026-08-25
 updated: 2026-08-25
 ---

--- a/docs/sprints/stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md
+++ b/docs/sprints/stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md
@@ -1,0 +1,141 @@
+---
+id: US-42.23
+title: "QC — Support manual claim for Bittensor native staking (#5064)"
+epic: EPIC-42
+status: ready
+priority: P2
+points: 5
+sprint: sprint-2026-W35
+version_shipped:
+prd_ref: []
+assignee: MaiThuongNinni
+commit:
+created: 2026-08-25
+updated: 2026-08-25
+---
+
+## Goal
+
+Check the new manual claim on Bittensor root staking: that the claim button appears only where it should, the amount shown matches the chain, the claim goes through, and the dust case gives a clear message instead of charging a fee for nothing.
+
+## Background
+
+This story covers [issue #5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) — *"Support manual claim for Bittensor native staking"*.
+
+**The issue is a title with an empty body**, so the checks below are derived from the code in [PR #5065](https://github.com/Koniverse/SubWallet-Extension/pull/5065) (+202 / −14, 9 files, approved by `lw-cdm`), not from a written spec. If requirements get written later, this story has to be re-read against them.
+
+### Root only, not subnets
+
+The claim applies to the **netuid 0 (root) position only**. The PR sets `claimReward: true` on the root handler (`tao.ts`) and explicitly `false` on the subnet handler (`dtao.ts`), with the reason in the code:
+
+> *Root claims redeem the basket of a netuid 0 position, subnet (alpha) positions have nothing to claim*
+
+So "subnet staking shows no claim button" is a **requirement**, not an oversight — AC-2 checks it.
+
+### What the amount actually is
+
+The unclaimed reward comes from a runtime call, `betaBasketRuntimeApi.getRootBasketOwed` — the total TAO the coldkey would realise right now by redeeming its beta baskets. **On older nodes that API does not exist and the code returns `0`**, so the UI settles at zero rather than hanging. That is a real state to test, not a bug (AC-11).
+
+### The dust threshold — the most interesting case
+
+The chain skips any validator owing less than `RootClaimableThreshold`, so a claim built purely from dust would **succeed as a no-op and still charge a fee**. The PR prevents that: it fetches the per-validator breakdown, filters out positions below the threshold, and if positions exist but none are claimable it rejects with:
+
+> *"No rewards to claim. You need at least {threshold} {symbol} pending on a validator before you can claim"*
+
+The threshold is stored as a substrate-fixed `I96F32` and the code divides the raw bits by `2^32` — `{ bits: 2147483648000000 }` is 500,000 rao. It falls back to `500000` rao (0.0005 TAO) when the query is absent, NaN, or ≤ 0.
+
+> **The scaling is handled correctly in the code** — this was flagged as a risk before the diff was read, and the diff answers it. What still has no automated test is whether the *number the user sees* matches the chain, which is why AC-4 and AC-5 verify against an explorer rather than against the app's own display.
+
+### Which extrinsic gets called
+
+- Exactly **one** claimable position → `claimRootWithHotkey(hotkey)`
+- Otherwise → `claimRoot([])` (the `subnets` argument is ignored since v4.4.1, kept so old call data still decodes)
+- Neither available → the claim is rejected as unsupported
+
+### UI changes
+
+`bondReward` has no meaning here — the claimed TAO is re-staked on root by the chain itself — so the **"bond reward" checkbox is hidden** for Bittensor. The rewards panel shows the value and uses the title *"Unclaimed rewards"*, and the claim screen only lists accounts whose unclaimed reward is greater than zero.
+
+**PR #5065 ships no test.**
+
+### One question the PR does not answer
+
+v1.3.86 **removed** a deprecated Bittensor root claim type ([#5045](https://github.com/Koniverse/SubWallet-Extension/issues/5045), QC'd in [US-42.11](US-42.11-qc-extension-pr5043-and-issue5045.md)). This PR adds a root claim on a **different** runtime API (`betaBasketRuntimeApi`). On the evidence it replaces rather than revives the old path — but neither the PR nor the issue says so, so AC-12 checks that the old removed behaviour has not come back.
+
+## Things to check
+
+**Where the claim appears**
+
+- [ ] AC-1: On a Bittensor **root (netuid 0)** native staking position, the rewards panel shows "Unclaimed rewards" with a value and a working Claim button
+- [ ] AC-2: On a Bittensor **subnet (alpha)** position, there is **no** claim button and no unclaimed-reward figure
+- [ ] AC-3: The claim screen lists only accounts with an unclaimed reward greater than zero — an account with nothing pending is not selectable
+
+**The amount is right**
+
+- [ ] AC-4: The unclaimed reward shown matches the chain — verify against an explorer or a runtime query, not against the app's own display
+- [ ] AC-5: The amount is scaled correctly (TAO, not rao, and not off by a factor of 2³²) — a wrong scale here shows a plausible number rather than an error
+- [ ] AC-6: After a successful claim, the unclaimed reward drops to zero (or to the remaining un-claimable dust) and the staked balance reflects the claim
+
+**Claiming works**
+
+- [ ] AC-7: A claim with **one** claimable validator goes through, with a correct fee on the confirm screen
+- [ ] AC-8: A claim with **several** claimable validators goes through and settles all of them
+- [ ] AC-9: The claim appears correctly in transaction history
+
+**The dust case — must not charge a fee for nothing**
+
+- [ ] AC-10: With pending rewards but all below the threshold, the claim is refused with the message *"No rewards to claim. You need at least {threshold} {symbol} pending on a validator…"*, **no transaction is submitted and no fee is charged**, and the threshold figure in the message is correct
+
+**Older runtimes and edge cases**
+
+- [ ] AC-11: On a node without the beta basket API, the unclaimed reward settles at 0 and the screen does not hang or error
+- [ ] AC-12: The deprecated root claim type removed in v1.3.86 (#5045) has **not** come back — there is one claim path, not two
+- [ ] AC-13: The "bond reward" checkbox is hidden on the Bittensor claim screen
+- [ ] AC-14: The new message is translated and readable in all 5 languages (en, ja, ru, vi, zh) — no raw key
+
+**Regression around it**
+
+- [ ] AC-15: Bittensor stake, unstake, and change-validator all still work — the handler was edited, so these need a pass
+- [ ] AC-16: AC-1 to AC-15 hold on a **fresh install** and on an **upgrade from v1.3.88** (existing Bittensor positions carried over correctly)
+
+## Steps
+
+- [ ] TASK-42.23.1 — Confirm the PR #5065 build is under test, note the commit
+- [ ] TASK-42.23.2 — Open a Bittensor root position, check the rewards panel, title and Claim button (AC-1)
+- [ ] TASK-42.23.3 — Open a Bittensor subnet position, confirm no claim is offered (AC-2)
+- [ ] TASK-42.23.4 — Check the account list on the claim screen against accounts with and without pending rewards (AC-3)
+- [ ] TASK-42.23.5 — Compare the unclaimed reward against an explorer / runtime query, check the scale (AC-4, AC-5)
+- [ ] TASK-42.23.6 — Claim with a single claimable validator, check fee and result (AC-7)
+- [ ] TASK-42.23.7 — Claim with several claimable validators, confirm all settle (AC-8)
+- [ ] TASK-42.23.8 — After claiming, re-check the unclaimed figure and the staked balance (AC-6)
+- [ ] TASK-42.23.9 — Check the claim in transaction history (AC-9)
+- [ ] TASK-42.23.10 — Find or set up an account whose pending rewards are all below the threshold, try to claim, confirm the message and that **no fee is charged** (AC-10)
+- [ ] TASK-42.23.11 — Test against a node without the beta basket API (AC-11)
+- [ ] TASK-42.23.12 — Confirm only one claim path exists, the #5045 one has not returned (AC-12)
+- [ ] TASK-42.23.13 — Check the bond-reward checkbox is hidden (AC-13)
+- [ ] TASK-42.23.14 — Read the new message in all 5 languages (AC-14)
+- [ ] TASK-42.23.15 — Run stake / unstake / change validator on Bittensor (AC-15)
+- [ ] TASK-42.23.16 — Repeat the main checks on **fresh install** and on **upgrade from v1.3.88** (AC-16)
+- [ ] TASK-42.23.17 — Log any bugs found in the manual test report
+
+## Bugs found
+
+Not run yet.
+
+## Test notes
+
+Not run yet. PR #5065 is open, approved by `lw-cdm`, and ships no test — so the numeric checks (AC-4, AC-5, AC-10) carry the weight here, since a scaling or threshold error shows a plausible wrong number rather than failing loudly.
+
+## Retest
+
+N/A — not run yet.
+
+## Cross-references
+
+- [Issue #5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) — Support manual claim for Bittensor native staking
+- [PR #5065](https://github.com/Koniverse/SubWallet-Extension/pull/5065) — the implementation under test
+- [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) — the dev-side story for this issue
+- [US-42.21](US-42.21-qc-release-extension-v1-3-89.md) — the v1.3.89 release gate this feeds into
+- [US-42.11](US-42.11-qc-extension-pr5043-and-issue5045.md) — QC of the #5045 removal this must not revive
+- [US-42.7](US-42.7-qc-recommend-validator-native-subnet-staking.md) — earlier native/subnet staking QC
+- Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/tests/test-reports/2026-08-25/report-manual.md
+++ b/docs/tests/test-reports/2026-08-25/report-manual.md
@@ -8,8 +8,8 @@ Not tied to one epic — this covers today's test tasks only.
 | Tester | MaiThuongNinni |
 | Environment | PR build |
 | Runner | manual (extension) |
-| Build under test | PR [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061), commit `cab8ebd5ee` |
-| Tasks tested | US-42.20 |
+| Build under test | PR [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061) commit `cab8ebd5ee` (US-42.20); PR [#5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) + merged chainlist (US-42.22) |
+| Tasks tested | US-42.20, US-42.22 |
 | Total bugs found | 0 |
 | P0 | 0 |
 | P1 | 0 |
@@ -39,6 +39,42 @@ None found. All checks passed:
 ### Note on the build
 
 This ran against an **unmerged** commit on an open PR with 0 reviews. If more commits land before #5061 merges, the passkey paths need a re-run against the merged head. The v1.3.89 release gate ([US-42.21](../../../sprints/stories/US-42.21-qc-release-extension-v1-3-89.md)) re-verifies this content on the real release build rather than inheriting this result.
+
+---
+
+## US-42.22 — Repoint KAH↔PAH USDt XCM refs ([#5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062)) — **P0**
+
+Checked on fresh install and on an upgrade from v1.3.88. **15 / 15 AC pass.**
+
+### Which halves of the fix are in the build
+
+This was the question the story was written to force, and both halves are present:
+
+| Half | Where | State |
+|---|---|---|
+| Data — bridged asset, missing multilocation, both `AssetRef` directions repointed, logo | [ChainList PR #709](https://github.com/Koniverse/SubWallet-ChainList/pull/709) | **merged 2026-08-24** |
+| Guard — `isXcmCurrencySupported()` | [PR #5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) | open, approved |
+
+So #5062 is genuinely fixed rather than merely blocked in the client.
+
+### Bugs
+
+None found. All checks passed:
+
+- Sending the KAH-native USDt from Kusama Asset Hub to Polkadot Asset Hub is no longer possible — the route is not offered, and the guard refuses it if reached.
+- The bridged USDt (`USDt-Polkadot`) transfers correctly in both directions, KAH → PAH and PAH → KAH, and the funds arrive with balances updating on both sides.
+- The bridged asset shows the right symbol, 6 decimals, its logo and a price; the KAH-native USDt now offers no XCM route at all.
+- USDC on the same KAH↔PAH route is unaffected — it was already modelled correctly.
+- Same-consensus XCM is untouched: relay → parachain, parachain → relay and parachain → parachain all work with correct fees.
+- Other genuinely supported cross-consensus routes still work — the guard blocks one token, not the bridge.
+- Both entry points refuse the bad route: the Send screen blocks it up front, and the swap and earning/XCM-deposit flows also refuse it with a readable message instead of a raw error.
+- With ParaSpell unreachable, valid XCM transfers still work — the guard fails open by design.
+- A blocked route stays blocked on repeated attempts in the same session (the 30-minute cache does not let it through).
+- The new error message reads correctly in all 5 languages (en, ja, ru, vi, zh).
+
+### Note on the build
+
+PR #5063 is still open and unmerged, so the guard half of this result is a claim about that build. The chainlist half **is** merged and live, so the data side of the fix is in production regardless of when #5063 lands.
 
 ---
 


### PR DESCRIPTION
## What this is

The two feature-level QC stories [W35](docs/sprints/sprint-2026-W35.md) recorded as missing — plus one of them run and closed. **Every dev story in the window now has a QC story.**

| Story | Issue | Pri | Points | Status |
| --- | --- | --- | --- | --- |
| [US-42.22](docs/sprints/stories/US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) — Repoint KAH↔PAH USDt XCM refs | [#5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062) | **P0** | 5 | **done — 15 / 15, no bugs** |
| [US-42.23](docs/sprints/stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md) — Manual claim for Bittensor native staking | [#5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) | P2 | 5 | `ready` |

Docs only. Both stories derive their checks from the **code in the open PRs**, because neither issue supplies testable requirements on its own — #5064 has an empty body, and #5062's spec describes the chainlist data fix, which is not what PR #5063 in this repo does.

## ⚠️ The correction this PR carries

Forcing "which halves of the fix are in the build?" into an acceptance criterion (AC-9) surfaced a factual error in the existing docs.

US-42.22, [US-13.19](docs/sprints/stories/US-13.19-repoint-kah-pah-usdt-xcm-refs.md) and W35 all recorded the chainlist half of the #5062 fix as **"no issue, no PR found"**. That was wrong:

| Half | Where | State |
| --- | --- | --- |
| **Data** — bridged asset, missing multilocation, both `AssetRef` directions repointed, logo | [ChainList PR #709](https://github.com/Koniverse/SubWallet-ChainList/pull/709) | **merged 2026-08-24** |
| **Guard** — `isXcmCurrencySupported()` | [PR #5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) | open, approved |

PR #709 carries exactly the four edits the issue prescribed (`ChainAsset.json` +71, `AssetRef.json` +4/−4, `AssetLogoMap.json` +1). It was missed because it is titled `[Issue-5062-extension]` and lives in the ChainList repo, so neither an issue search nor a PR search in this repo surfaces it.

**This inverts the recorded risk.** The bad route is removed from production data, not merely blocked in the client — so #5062 is genuinely fixed, and PR #5063's guard is belt to the data fix's braces. Corrected in all three places as an explicit correction rather than a quiet edit.

## US-42.22 — P0, 15 / 15 pass

Run on fresh install and upgrade from v1.3.88, against PR #5063 plus the merged chainlist data.

- The route that trapped funds is gone: KAH-native USDt offers **no** XCM route at all, and the guard refuses it if reached.
- Bridged `USDt-Polkadot` moves correctly in both directions, with the right symbol, 6 decimals, logo and price.
- **Nothing else was caught by the guard** — USDC on the same KAH↔PAH route, same-consensus XCM, and other supported cross-consensus routes all still work. It blocks one token, not the bridge.
- **Both entry points refuse it**: `Extension.ts` up front, and `buildXcm()` as the backstop the swap and earning flows rely on.

**Worth knowing at the release gate:** the guard **fails open** on a network error — intended (the dry-run is still ahead), but it means the guard alone is not a defence during a ParaSpell outage. The data fix is what actually removes the route. AC-12 on [US-42.21](docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md) still asks the gate to confirm both halves on the real release build.

## US-42.23 — ready, not run

Root (netuid 0) only: `claimReward` is `true` in `tao.ts` and explicitly `false` in `dtao.ts`, so **"no claim button on subnet positions" is a requirement**, not an oversight (AC-2).

Also correcting an earlier note: the `I96F32` `2^32` scaling risk **is handled correctly** in the code. What has no test is whether the number the *user* sees matches the chain, so AC-4/AC-5 verify against an explorer. **AC-10** covers the case worth having — with all rewards below the threshold, a claim would otherwise succeed as a no-op **and still charge a fee**.

## Also in this PR

- **US-42.20 corrected**: it recorded #5058 as OPEN. The issue was closed by hand on 2026-08-25 with no commit attached while PR #5061 is still open and unmerged — so `dev` does not contain the feature. The QC pass and the closed issue are both true; neither makes it released, and `version_shipped` stays empty. Matches the reading in `5b291608cf`.
- **US-42.21 refreshed**: PR #5065 now approved by `lw-cdm`, the #5062 background rewritten around the merged chainlist half, and a stale `AC-13` pointer now reads `AC-12`.
- Test report for 2026-08-25 now covers US-42.20 and US-42.22.
- EPIC-42 and W35 updated — W35 is 7 stories / 41 points, two QC stories `done`.

## Nothing has shipped

All three dev PRs (#5061, #5063, #5065) are still open. Both QC passes ran against unmerged PR builds, so each is a claim about a specific commit. The one exception is the chainlist half of the P0, which is merged and live in production data independently of this repo.

## Checks

Rebased onto `5b291608cf`; the single W35 conflict was resolved in favour of dev's wording. `koni-docs-check-ids` shows no new failures — the pre-existing `US-42.10 version_shipped` error is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
