### PR TITLE
qc: drop Bittensor manual claim (#5064) from v1.3.89 scope, AC-2 dev regression pass

### DIFF
--- a/docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md
+++ b/docs/sprints/stories/US-42.21-qc-release-extension-v1-3-89.md
@@ -11,7 +11,7 @@ prd_ref: []
 assignee: MaiThuongNinni
 commit:
 created: 2026-08-25
-updated: 2026-08-27
+updated: 2026-08-28
 ---
 
 ## Goal
@@ -28,11 +28,12 @@ Planned release content for v1.3.89:
 | --- | --- | --- | --- | --- |
 | P0 — Repoint KAH↔PAH USDt XCM refs | [#5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062) | [#5063](https://github.com/Koniverse/SubWallet-Extension/pull/5063) | [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) | [US-42.22](US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md) |
 | Biometric / passkey login | [#5058](https://github.com/Koniverse/SubWallet-Extension/issues/5058) | [#5061](https://github.com/Koniverse/SubWallet-Extension/pull/5061) | [US-5.16](US-5.16-biometric-passkey-login.md) | [US-42.20](US-42.20-qc-issue-5058-biometric-passkey-login.md) |
-| Manual claim for Bittensor native staking | [#5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) | [#5065](https://github.com/Koniverse/SubWallet-Extension/pull/5065) | [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) | [US-42.23](US-42.23-qc-issue-5064-bittensor-manual-claim.md) |
 
-Each item already has its own QC story covering the feature-level checks. This story is the release gate — it re-verifies the same content lands correctly as it moves through each build stage, plus a regression pass of the app's main functions at each stage. All three feature QC runs were done against unmerged PR builds, so this gate re-verifies rather than inherits them.
+The Bittensor manual claim (#5064) was in the plan but has been dropped from v1.3.89 — that issue is being scheduled for a later release, so it is out of scope for this run. Its feature QC stays in [US-42.23](US-42.23-qc-issue-5064-bittensor-manual-claim.md) and carries over to whichever release picks the issue up.
 
-Two points that shape the run. #5062 is a P0 that has already stranded a real transfer, and its fix spans two repos — the ChainList data ([PR #709](https://github.com/Koniverse/SubWallet-ChainList/pull/709), merged 08-24) and the guard in PR #5063 (still open); AC-12 checks both halves are in the build. #5064's claim amount can be quietly wrong rather than error out, so AC-13 verifies it against an explorer, not against the app's own display.
+Each item already has its own QC story covering the feature-level checks. This story is the release gate — it re-verifies the same content lands correctly as it moves through each build stage, plus a regression pass of the app's main functions at each stage. Both feature QC runs were done against unmerged PR builds, so this gate re-verifies rather than inherits them.
+
+One point shapes the run. #5062 is a P0 that has already stranded a real transfer, and its fix spans two repos — the ChainList data ([PR #709](https://github.com/Koniverse/SubWallet-ChainList/pull/709), merged 08-24) and the guard in PR #5063 (still open); AC-12 checks both halves are in the build.
 
 ## Stages
 
@@ -44,71 +45,61 @@ Two points that shape the run. #5062 is a P0 that has already stranded a real tr
 ## Things to check
 
 - [x] AC-1a: Passkey login (#5058) works correctly after merge into the dev environment
-- [ ] AC-1b: KAH↔PAH XCM refs (#5062) works correctly after merge into the dev environment
-- [ ] AC-1c: Bittensor manual claim (#5064) works correctly after merge into the dev environment
-- [ ] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
+- [x] AC-1b: KAH↔PAH XCM refs (#5062) works correctly after merge into the dev environment
+- [x] AC-2: Regression pass on dev finds no new issues in the app's main functions (see Regression checklist)
 - [ ] AC-3a: Passkey login (#5058) works correctly on the master build
 - [ ] AC-3b: KAH↔PAH XCM refs (#5062) works correctly on the master build
-- [ ] AC-3c: Bittensor manual claim (#5064) works correctly on the master build
 - [ ] AC-4: Regression pass on the master build finds no new issues in the app's main functions
 - [ ] AC-5a: Passkey login (#5058) works correctly on the draft release build
 - [ ] AC-5b: KAH↔PAH XCM refs (#5062) works correctly on the draft release build
-- [ ] AC-5c: Bittensor manual claim (#5064) works correctly on the draft release build
 - [ ] AC-6: Regression pass on the draft release build finds no new issues in the app's main functions
 - [ ] AC-7a: Passkey login (#5058) is live and working on production, no critical issues
 - [ ] AC-7b: KAH↔PAH XCM refs (#5062) is live and working on production, no critical issues
-- [ ] AC-7c: Bittensor manual claim (#5064) is live and working on production, no critical issues
 - [ ] AC-8: The version shown in the extension is 1.3.89 on the draft and production builds
 - [ ] AC-9: The master password still unlocks the wallet on every stage, with the passkey both on and off — nobody can be locked out
 - [ ] AC-10: AC-1 to AC-9 hold on a fresh install (no prior version or data)
 - [ ] AC-11: AC-1 to AC-9 hold on an upgrade from v1.3.88 (existing accounts, chains, settings and master password carried over, no data loss)
 - [ ] AC-12: The KAH↔PAH USDt route (#5062) is confirmed safe in the build — check which halves shipped: the chainlist data fix, the `xcm/utils.ts` guard, or both. If only the guard shipped, the route must be blocked in the UI and the data must be confirmed as still-wrong-but-unreachable, not assumed fixed
-- [ ] AC-13: The Bittensor claim amount (#5064) matches the chain — checked against an explorer or a runtime query, not just against what the app displays
 
 ## Regression checklist (main functions)
 
 Run this list at each stage (dev, master, draft, production quick recheck at reduced depth):
 
-- [ ] Create a new account / import an existing account (mnemonic, private key)
-- [ ] Switch between accounts, view balances across chains
-- [ ] Unlock with the master password, and unlock with the passkey if it is on
-- [ ] Auto-lock triggers on time and the wallet reopens correctly
-- [ ] Send a native token, confirm it goes through with correct fee display
-- [ ] Receive a token (show/copy address, QR)
-- [ ] Swap tokens (at least one route)
-- [ ] Stake and unstake on at least one network
-- [ ] Bittensor native staking: manual claim works, and the claimed amount matches the chain — verify against an explorer, since a scaling bug here shows a plausible wrong number rather than an error (covers #5064)
-- [ ] XCM transfer relay chain → parachain
-- [ ] XCM transfer parachain → parachain, with correct fee and balance update on both sides
-- [ ] XCM USDt Kusama Asset Hub ↔ Polkadot Asset Hub — the route is either correctly repointed and a real transfer arrives, or it is blocked outright. Tokens must not leave the source chain on a route that cannot deliver them (covers #5062, the P0)
-- [ ] Connect to a dApp (WalletConnect or injected), sign a message and a transaction
-- [ ] Export account (JSON / seed phrase) and remove account
+- [x] Create a new account / import an existing account (mnemonic, private key)
+- [x] Switch between accounts, view balances across chains
+- [x] Unlock with the master password, and unlock with the passkey if it is on
+- [x] Auto-lock triggers on time and the wallet reopens correctly
+- [x] Send a native token, confirm it goes through with correct fee display
+- [x] Receive a token (show/copy address, QR)
+- [x] Swap tokens (at least one route)
+- [x] Stake and unstake on at least one network
+- [x] XCM transfer relay chain → parachain
+- [x] XCM transfer parachain → parachain, with correct fee and balance update on both sides
+- [x] XCM USDt Kusama Asset Hub ↔ Polkadot Asset Hub — the route is either correctly repointed and a real transfer arrives, or it is blocked outright. Tokens must not leave the source chain on a route that cannot deliver them (covers #5062, the P0)
+- [x] Connect to a dApp (WalletConnect or injected), sign a message and a transaction
+- [x] Export account (JSON / seed phrase) and remove account
 - [ ] App upgrade path: install v1.3.88, add data, upgrade to v1.3.89, confirm data, settings and the master password are preserved
 
 ## Steps
 
 - [ ] TASK-42.21.1 — Confirm the real release content against the release note, update the Background table if it changed
 - [ ] TASK-42.21.1b — For #5062, confirm which halves of the fix are in the build: the `SubWallet-ChainList` data edits, the `xcm/utils.ts` guard, or both. Do not sign off the P0 on the guard alone without saying so (AC-12)
-- [ ] TASK-42.21.2 — Merge the passkey login (#5058), the XCM ref repoint (#5062) and the Bittensor manual claim (#5064) into the extension on dev
+- [ ] TASK-42.21.2 — Merge the passkey login (#5058) and the XCM ref repoint (#5062) into the extension on dev
 - [x] TASK-42.21.3a — Verify passkey login (#5058) on dev (steps in [US-42.20](US-42.20-qc-issue-5058-biometric-passkey-login.md))
-- [ ] TASK-42.21.3b — Verify KAH↔PAH XCM refs (#5062) on dev (steps in [US-42.22](US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md))
-- [ ] TASK-42.21.3c — Verify Bittensor manual claim (#5064) on dev (steps in [US-42.23](US-42.23-qc-issue-5064-bittensor-manual-claim.md))
-- [ ] TASK-42.21.4 — Run the regression checklist on dev
+- [x] TASK-42.21.3b — Verify KAH↔PAH XCM refs (#5062) on dev (steps in [US-42.22](US-42.22-qc-issue-5062-repoint-kah-pah-usdt-xcm.md))
+- [x] TASK-42.21.4 — Run the regression checklist on dev
 - [ ] TASK-42.21.5 — Build from master with the release content, deploy to a near-production environment
 - [ ] TASK-42.21.6a — Verify passkey login (#5058) on the master build
 - [ ] TASK-42.21.6b — Verify KAH↔PAH XCM refs (#5062) on the master build
-- [ ] TASK-42.21.6c — Verify Bittensor manual claim (#5064) on the master build
 - [ ] TASK-42.21.7 — Run the regression checklist on the master build
 - [ ] TASK-42.21.8 — Test the draft release build (production-like, draft form), confirm the version reads 1.3.89
 - [ ] TASK-42.21.9a — Verify passkey login (#5058) on the draft build
 - [ ] TASK-42.21.9b — Verify KAH↔PAH XCM refs (#5062) on the draft build
-- [ ] TASK-42.21.9c — Verify Bittensor manual claim (#5064) on the draft build
 - [ ] TASK-42.21.10 — Run the regression checklist on the draft build
 - [ ] TASK-42.21.12 — Run the draft build as a fresh install and repeat the release-item checks
 - [ ] TASK-42.21.13 — Run the draft build as an upgrade from v1.3.88 and repeat the release-item checks, plus confirm no data loss and that the old master password still works
 - [ ] TASK-42.21.14a — After publish, recheck passkey login (#5058) on production
 - [ ] TASK-42.21.14b — After publish, recheck KAH↔PAH XCM refs (#5062) on production
-- [ ] TASK-42.21.14c — After publish, recheck Bittensor manual claim (#5064) on production
 - [ ] TASK-42.21.14d — Quick recheck of the core functions on production
 - [ ] TASK-42.21.15 — Log any bugs found, tag with the stage they were found on (dev / master / draft / production)
 
@@ -120,9 +111,11 @@ Not run yet.
 
 - Tested on: dev environment only — the release has not been cut, so the master, draft and production stages cannot start
 - Environment: dev build, code not committed
-- Passed: 1 / 21 AC (AC-1a)
+- Passed: 3 / 16 AC (AC-1a, AC-1b, AC-2)
 
-Passkey login (#5058) passed on dev on 2026-08-27. The code is not committed, so this is a claim about that dev build and not about a merged branch — it has to be re-checked once the code lands. The other two dev items (AC-1b, AC-1c) and the dev regression pass (AC-2) are not run.
+Passkey login (#5058) and the P0 KAH↔PAH USDt XCM refs (#5062) both passed on dev on 2026-08-27. The code is not committed, so these are claims about that dev build and not about a merged branch — both have to be re-checked once the code lands. AC-12 still applies at the release build: the ChainList data half is already live, but PR #5063 is not merged, so confirm both halves are present.
+
+The dev regression pass (AC-2) is done: 13 of the 14 checklist items ran and found no new issues. The upgrade-path item could not run on dev — v1.3.89 is not cut yet, so there is no build to upgrade to. It runs at the draft stage (TASK-42.21.13). The dev stage is now complete; the master, draft and production stages still cannot start.
 
 ## Retest
 
@@ -135,7 +128,5 @@ No retest carried in. The passkey content was already QC'd at PR level by [US-42
 - [US-42.6](US-42.6-qc-release-extension-v1-3-84.md) — the Extension release-gate template this story follows
 - [US-5.16](US-5.16-biometric-passkey-login.md) — dev story for the passkey work (`review`)
 - [US-13.19](US-13.19-repoint-kah-pah-usdt-xcm-refs.md) — dev story for the P0 KAH↔PAH USDt XCM fix (`review`)
-- [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) — dev story for the Bittensor manual claim (`review`)
 - [Issue #5062](https://github.com/Koniverse/SubWallet-Extension/issues/5062) — Repoint KAH↔PAH XCM refs (P0)
-- [Issue #5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) — Support manual claim for Bittensor native staking
 - Epic: [EPIC-42](../epics/EPIC-42.md)

--- a/docs/sprints/stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md
+++ b/docs/sprints/stories/US-42.23-qc-issue-5064-bittensor-manual-claim.md
@@ -11,7 +11,7 @@ prd_ref: []
 assignee: MaiThuongNinni
 commit: 85ce0265fc
 created: 2026-08-25
-updated: 2026-08-27
+updated: 2026-08-28
 ---
 
 ## Goal
@@ -137,7 +137,7 @@ None.
 
 **Root only, as designed** (AC-1, AC-2): the claim shows on netuid 0 and is absent on subnet (alpha) positions. Old runtimes without the beta basket API settle at 0 rather than hanging (AC-11), and the bond-reward checkbox is hidden (AC-13).
 
-**One caveat on the build.** PR #5065 is still **open and unmerged**, approved by `lw-cdm` at head `ac5b0a6ac9`, and **ships no test** — so this manual pass is the only verification the feature has, and it is a claim about that commit, not about whatever merges. If more commits land, the numeric checks (AC-4, AC-5, AC-10) need a re-run against the merged head. The v1.3.89 release gate ([US-42.21](US-42.21-qc-release-extension-v1-3-89.md)) re-verifies this on the real release build rather than inheriting this result.
+**One caveat on the build.** PR #5065 is still **open and unmerged**, approved by `lw-cdm` at head `ac5b0a6ac9`, and **ships no test** — so this manual pass is the only verification the feature has, and it is a claim about that commit, not about whatever merges. If more commits land, the numeric checks (AC-4, AC-5, AC-10) need a re-run against the merged head. #5064 has since been dropped from the v1.3.89 release scope and is being scheduled for a later one, so no release gate re-verifies this result yet — whichever release picks the issue up has to re-run these checks on its real build.
 
 ## Retest
 
@@ -148,7 +148,7 @@ N/A — all AC passed on the first run.
 - [Issue #5064](https://github.com/Koniverse/SubWallet-Extension/issues/5064) — Support manual claim for Bittensor native staking
 - [PR #5065](https://github.com/Koniverse/SubWallet-Extension/pull/5065) — the implementation under test
 - [US-12.23](US-12.23-bittensor-manual-claim-native-staking.md) — the dev-side story for this issue
-- [US-42.21](US-42.21-qc-release-extension-v1-3-89.md) — the v1.3.89 release gate this feeds into
+- [US-42.21](US-42.21-qc-release-extension-v1-3-89.md) — the v1.3.89 release gate; #5064 was dropped from its scope, so this QC does not feed into it
 - [US-42.11](US-42.11-qc-extension-pr5043-and-issue5045.md) — QC of the #5045 removal this must not revive
 - [US-42.7](US-42.7-qc-recommend-validator-native-subnet-staking.md) — earlier native/subnet staking QC
 - Epic: [EPIC-42](../epics/EPIC-42.md)


### PR DESCRIPTION
## What changed

The Bittensor manual claim (#5064) is no longer part of the v1.3.89 release — the issue is being scheduled for a later one. This PR takes it out of the release gate and records the dev-stage regression pass.

### US-42.21 — QC Release Extension v1.3.89

Removed from scope:

- the #5064 row in the release-content table
- AC-1c, AC-3c, AC-5c, AC-7c (per-stage feature checks) and AC-13 (claim amount vs the chain)
- the Bittensor item in the regression checklist
- TASK-42.21.3c / 6c / 9c / 14c, and #5064 in TASK-42.21.2
- the US-12.23 and Issue #5064 cross-references

AC count goes from 21 to 16. A short note in Background says why the item was dropped and where its QC lives.

Recorded:

- AC-2 passes. 13 of the 14 dev regression items ran and found no new issues.
- The upgrade-path item could not run on dev — v1.3.89 is not cut, so there is no build to upgrade to. It runs at the draft stage (TASK-42.21.13).
- Test notes now read 3 / 16 AC (AC-1a, AC-1b, AC-2). The dev stage is complete; master, draft and production still cannot start.

Points stay at 8. The dropped item cuts 4 feature verifications, not the 4 x 14 regression runs that carry the weight — and US-42.19 is 8 points at 10 AC / 13 tasks, so 16 AC / 20 tasks is not a smaller story.

### US-42.23 — QC Bittensor manual claim (#5064)

Still `done`, 16/16 against commit `ac5b0a6ac9` — the result itself is unchanged. What changed is where it goes: it no longer feeds into the v1.3.89 gate, so the page now says no release gate re-verifies it yet, and whichever release picks up #5064 has to re-run the numeric checks on its real build.

## Notes

Docs only. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
